### PR TITLE
Add support for "fhdtv"

### DIFF
--- a/TVHeadEnd/DataHelper/ChannelDataHelper.cs
+++ b/TVHeadEnd/DataHelper/ChannelDataHelper.cs
@@ -184,6 +184,7 @@ namespace TVHeadEnd.DataHelper
                                                 break;
                                             case "sdtv":
                                             case "hdtv":
+                                            case "fhdtv":
                                             case "uhdtv":
                                                 ci.ChannelType = ChannelType.TV;
                                                 serviceFound = true;

--- a/TVHeadEnd/TVHeadEnd.csproj
+++ b/TVHeadEnd/TVHeadEnd.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>7.0.0.0</AssemblyVersion>
-    <FileVersion>7.0.0.0</FileVersion>
+    <AssemblyVersion>8.0.0.0</AssemblyVersion>
+    <FileVersion>8.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "TVHeadend"
 guid: "3fd018e5-5e78-4e58-b280-a0c068febee0"
-version: "7.0.0.0"
+version: "8.0.0.0"
 targetAbi: "10.7.0.0"
 framework: "net5.0"
 owner: "jellyfin"


### PR DESCRIPTION
I ran into a similar issue to the one described in https://github.com/jellyfin/jellyfin-plugin-tvheadend/issues/14
Based on this comment I was able to resolve my issue: https://github.com/jellyfin/jellyfin-plugin-tvheadend/issues/14#issuecomment-592775364

Here's the log error I got on Jellyfin:

```
TVHeadEnd.LiveTvService: [TVHclient] ChannelDataHelper: unkown service tag '"fhdtv"' - will be ignored.
TVHeadEnd.LiveTvService: [TVHclient] ChannelDataHelper: unable to detect service-type (tvheadend tag!!!) from service list:
```