### PR TITLE
Fix DLNA streaming

### DIFF
--- a/TVHeadEnd/AccessTicketHandler.cs
+++ b/TVHeadEnd/AccessTicketHandler.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TVHeadEnd.HTSP;
+using TVHeadEnd.HTSP_Responses;
+using TVHeadEnd.TimeoutHelper;
+
+namespace TVHeadEnd;
+
+public class AccessTicketHandler
+{
+    private readonly ILogger<AccessTicketHandler> _logger;
+
+    private readonly HTSConnectionHandler _htsConnectionHandler;
+    private readonly string _ticketItemType;
+    private readonly TimeSpan _requestTimeout;
+    private readonly TimeSpan _ticketLifeSpan;
+
+    private volatile int _ticketIdSequence;
+
+    public enum TicketType : byte { Channel, Recording };
+
+    public record Ticket
+    {
+        public string Id { get; init; }
+        public string Path { get; init; }
+        public string TicketParam { get; init; }
+        public DateTime Expires { get; init; }
+    }
+
+    private readonly ConcurrentDictionary<string, Ticket> _ticketCache = new();
+
+    internal AccessTicketHandler(
+        ILoggerFactory loggerFactory, HTSConnectionHandler htsConnectionHandler,
+        TimeSpan requestTimeout, TimeSpan ticketLifeSpan, TicketType ticketType)
+    {
+        _logger = loggerFactory.CreateLogger<AccessTicketHandler>();
+        _htsConnectionHandler = htsConnectionHandler;
+        _requestTimeout = requestTimeout;
+        _ticketLifeSpan = ticketLifeSpan;
+
+        _ticketItemType = ticketType switch
+        {
+            TicketType.Channel => "channelId",
+            TicketType.Recording => "dvrId",
+            _ => throw new ArgumentException("undefined ticketType")
+        };
+    }
+
+    public async Task<Ticket> GetTicket(string itemId, CancellationToken cancellationToken)
+    {
+        var now = DateTime.Now;
+        Ticket ticket;
+
+        while (_ticketCache.TryGetValue(itemId, out ticket))
+        {
+            if (ticket.Expires > now)
+            {
+                return ticket; // non-expired ticket from cache
+            }
+
+            _ticketCache.TryRemove(new KeyValuePair<string, Ticket>(itemId, ticket));
+        }
+
+        var ticketResponse = await RequestNewTicket(itemId, cancellationToken);
+
+        ticket = _ticketCache.GetOrAdd(itemId, _ => new Ticket()
+        {
+            Id = $"{NextTicketId()}",
+            Path = ticketResponse.getString("path"),
+            TicketParam = ticketResponse.getString("ticket"),
+            Expires = now + _ticketLifeSpan,
+        });
+
+        _logger.LogInformation($"[TVHclient] AccessTicketHandler.GetAccessTicket: New ticket created for {_ticketItemType}={itemId}, Ticket-Id={ticket.Id}. Expires at {ticket.Expires}");
+
+        return ticket;
+    }
+
+    private async Task<HTSMessage> RequestNewTicket(string itemId, CancellationToken cancellationToken)
+    {
+        var request = new HTSMessage { Method = "getTicket" };
+        request.putField(_ticketItemType, itemId);
+
+        var runner = new TaskWithTimeoutRunner<HTSMessage>(_requestTimeout);
+        var result = await runner.RunWithTimeout(Task.Factory.StartNew(() =>
+        {
+            var response = new LoopBackResponseHandler();
+            _htsConnectionHandler.SendMessage(request, response);
+            return response.getResponse();
+        }, cancellationToken));
+
+        if (!result.HasTimeout)
+        {
+            return result.Result;
+        }
+
+        _logger.LogError("[TVHclient] AccessTicketHandler.GetAccessTicket: can't obtain playback authentication ticket from TVH because the timeout was reached");
+
+        throw new TimeoutException("Obtaining playback authentication ticket from TVH caused a network timeout");
+    }
+
+    private int NextTicketId()
+    {
+        int id;
+        for (; (id = Interlocked.Increment(ref _ticketIdSequence)) < 0;)
+        {
+            _ticketIdSequence = Math.Max(0, _ticketIdSequence);
+        }
+
+        return id;
+    }
+}

--- a/TVHeadEnd/DataHelper/ChannelDataHelper.cs
+++ b/TVHeadEnd/DataHelper/ChannelDataHelper.cs
@@ -187,6 +187,7 @@ namespace TVHeadEnd.DataHelper
                                             case "fhdtv":
                                             case "uhdtv":
                                                 ci.ChannelType = ChannelType.TV;
+                                                ci.IsHD = type != "sdtv";
                                                 serviceFound = true;
                                                 break;
                                             case "other":

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -48,9 +48,13 @@ namespace TVHeadEnd
             _htsConnectionHandler = HTSConnectionHandler.GetInstance(loggerFactory, httpClientFactory);
             _htsConnectionHandler.setLiveTvService(this);
 
-            var ticketLifeSpan = TimeSpan.FromSeconds(30); // TVH built-in minimum ticket-TTL.
-            _channelTicketHandler = new AccessTicketHandler(loggerFactory, _htsConnectionHandler, TIMEOUT, ticketLifeSpan, Channel);
-            _recordingTicketHandler = new AccessTicketHandler(loggerFactory, _htsConnectionHandler, TIMEOUT, ticketLifeSpan, Recording);
+            {
+                var lifeSpan = TimeSpan.FromSeconds(15);       // Revalidate tickets every 15 seconds
+                var requestTimeout = TimeSpan.FromSeconds(10); // First request retry after 10 seconds
+                var retries = 2;                               // Number of times to retry getting tickets
+                _channelTicketHandler = new AccessTicketHandler(loggerFactory, _htsConnectionHandler, requestTimeout, retries, lifeSpan, Channel);
+                _recordingTicketHandler = new AccessTicketHandler(loggerFactory, _htsConnectionHandler, requestTimeout, retries, lifeSpan, Recording);
+            }
 
             //Added for stream probing
             _mediaEncoder = mediaEncoder;

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -472,10 +472,10 @@ namespace TVHeadEnd
             }
         }
 
-
-        public Task<List<MediaSourceInfo>> GetChannelStreamMediaSources(string channelId, CancellationToken cancellationToken)
+        public async Task<List<MediaSourceInfo>> GetChannelStreamMediaSources(string channelId, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            var source = await GetChannelStream(channelId, string.Empty, cancellationToken);
+            return new List<MediaSourceInfo>() { source };
         }
 
         public async Task<SeriesTimerInfo> GetNewTimerDefaultsAsync(CancellationToken cancellationToken, ProgramInfo program = null)
@@ -630,9 +630,10 @@ namespace TVHeadEnd
             }
         }
 
-        public Task<List<MediaSourceInfo>> GetRecordingStreamMediaSources(string recordingId, CancellationToken cancellationToken)
+        public async Task<List<MediaSourceInfo>> GetRecordingStreamMediaSources(string recordingId, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            var source = await GetRecordingStream(recordingId, string.Empty, cancellationToken);
+            return new List<MediaSourceInfo>() { source };
         }
 
         public async Task<IEnumerable<SeriesTimerInfo>> GetSeriesTimersAsync(CancellationToken cancellationToken)

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -422,7 +422,7 @@ namespace TVHeadEnd
 
                 MediaSourceInfo livetvasset = new MediaSourceInfo();
 
-                livetvasset.Id = ticket.Id;
+                livetvasset.Id = channelId;
 
                 // Use HTTP basic auth in HTTP header instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
@@ -452,8 +452,8 @@ namespace TVHeadEnd
             {
                 return new MediaSourceInfo
                 {
-                    Id = ticket.Id,
-                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path + "?ticket=" + ticket.TicketParam,
+                    Id = channelId,
+                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
                     MediaStreams = new List<MediaStream>
                     {
@@ -581,7 +581,7 @@ namespace TVHeadEnd
 
                 MediaSourceInfo recordingasset = new MediaSourceInfo();
 
-                recordingasset.Id = ticket.Id;
+                recordingasset.Id = recordingId;
 
                 // Use HTTP basic auth instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
                 recordingasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
@@ -610,8 +610,8 @@ namespace TVHeadEnd
             {
                 return new MediaSourceInfo
                 {
-                    Id = ticket.Id,
-                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path + "?ticket=" + ticket.TicketParam,
+                    Id = recordingId,
+                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
                     MediaStreams = new List<MediaStream>
                     {


### PR DESCRIPTION
This PR fixes a problem when an attempt is made to forward a TVH stream to a DLNA device. Before this change `ffmpeg` received no source (as `MediaPath` is set to a null value) and failed to process the stream.

This PR consists of 2 parts:
* The actual fix for DLNA. Achieved by implementing `GetChannelStreamMediaSources` and `GetRecordingStreamMediaSources`.
* A cache for access tickets. Is required after implementing the additional methods to ensure that `MediaSourceId` is stable across subsequent requests for the same channel or recording.

As a side effect the roundtrips to TVH are reduced when tickets are cached. The cache TTL for the tickets is the smallest configurable ticket TTL in TVH (30 seconds).

---

Done: ~~Update: Changed to WIP/Draft. TVH should return tickets from cache until they expire. This implementation should be improved to keep the same ticket ID as long as TVH returns the same ticket.~~