### PR TITLE
Fix channel images

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -162,11 +162,11 @@ namespace TVHeadEnd
             if (_enableSubsMaudios)
             {
                 // Use HTTP basic auth instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                _httpBaseUrl = "http://" + _userName + ":" + _password + "@" + _tvhServerName + ":" + _httpPort + _webRoot;
+                _httpBaseUrl = $"http://{Uri.EscapeDataString(_userName)}:{Uri.EscapeDataString(_password)}@{_tvhServerName}:{_httpPort}{_webRoot}";
             }
             else
             {
-                _httpBaseUrl = "http://" + _tvhServerName + ":" + _httpPort + _webRoot;
+                _httpBaseUrl = $"http://{_tvhServerName}:{_httpPort}{_webRoot}";
             }
 
             string authInfo = _userName + ":" + _password;
@@ -194,7 +194,7 @@ namespace TVHeadEnd
                 }
                 else
                 {
-                    string requestStr = "http://" + _tvhServerName + ":" + _httpPort + _webRoot + "/" + channelIcon;
+                    string requestStr = $"http://{_tvhServerName}:{_httpPort}{_webRoot}/{channelIcon}";
                     request.RequestUri = new Uri(requestStr);
                     request.Headers.Authorization = AuthenticationHeaderValue.Parse(_headers[HeaderNames.Authorization]);
 
@@ -295,7 +295,7 @@ namespace TVHeadEnd
             }
             else
             {
-                return "http://" + _userName + ":" + _password + "@" +_tvhServerName + ":" + _httpPort + _webRoot + "/" + channelIcon;
+                return $"http://{Uri.EscapeDataString(_userName)}:{Uri.EscapeDataString(_password)}@{_tvhServerName}:{_httpPort}{_webRoot}/{channelIcon}";
             }
         }
 

--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -278,39 +276,10 @@ namespace TVHeadEnd
             }
         }
 
-        public string GetChannelImageUrl(string channelId)
-        {
-            _logger.LogDebug("[TVHclient] HTSConnectionHandler.GetChannelImage: channelId: {id}", channelId);
-
-            String channelIcon = _channelDataHelper.GetChannelIcon4ChannelId(channelId);
-
-            if (string.IsNullOrEmpty(channelIcon))
-            {
-                return null;
-            }
-
-            if (channelIcon.StartsWith("http"))
-            {
-                return _channelDataHelper.GetChannelIcon4ChannelId(channelId);
-            }
-            else
-            {
-                return $"http://{Uri.EscapeDataString(_userName)}:{Uri.EscapeDataString(_password)}@{_tvhServerName}:{_httpPort}{_webRoot}/{channelIcon}";
-            }
-        }
-
         public Dictionary<string, string> GetHeaders()
         {
             return new Dictionary<string, string>(_headers);
         }
-
-        //private static Stream ImageToPNGStream(Image image)
-        //{
-        //    Stream stream = new System.IO.MemoryStream();
-        //    image.Save(stream, ImageFormat.Png);
-        //    stream.Position = 0;
-        //    return stream;
-        //}
 
         private void ensureConnection()
         {

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -113,7 +113,7 @@ namespace TVHeadEnd
             {
                 return Task.FromResult(new DynamicImageResponse
                 {
-                    Path = "https://github.com/MediaBrowser/Tvheadend/raw/master/TVHeadEnd/Images/TVHeadEnd.png?raw=true",
+                    Path = "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tvheadend.png",
                     Protocol = MediaProtocol.Http,
                     HasImage = true
                 });

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -268,14 +268,14 @@ namespace TVHeadEnd
                 var tvhServerName = config.TVH_ServerName.Trim();
                 var httpPort = config.HTTP_Port;
                 var htspPort = config.HTSP_Port;
-                var webRoot = config.WebRoot;            
+                var webRoot = config.WebRoot;
                 if (webRoot.EndsWith("/"))
                 {
                     webRoot = webRoot.Substring(0, webRoot.Length - 1);
                 }
                 var userName = config.Username.Trim();
                 var password = config.Password.Trim();
-                return "http://" + userName + ":" + password + "@" + tvhServerName + ":" + httpPort + webRoot + "/dvrfile/" + Id;
+                return $"http://{Uri.EscapeDataString(userName)}:{Uri.EscapeDataString(password)}@{tvhServerName}:{httpPort}{webRoot}/dvrfile/{Id}";
             }
             catch (Exception)
             {


### PR DESCRIPTION
I was trying to get the Jellyfin app working on my TV and in the server logs I was seeing a lot of errors about objects being in the wrong state and not being able to parse URL host names. The invalid state messages are a Jellyfin bug where it throws the wrong type of exception when it fails to download an image. The URL host name problem turned out to be because my password contained special characters and they weren't being escaped when building URLs.

I changed my password to a simpler one but it still didn't work. Jellyfin wasn't sending the username and password from the URL. There are two problems here. First, it doesn't send basic authentication when credentials are provided in the URL and, second, Tvheadend by default doesn't accept basic authentication anymore. I made `LiveTvService` implement `IDynamicImageProvider` and it still doesn't work without telling Tvheadend to accept basic authentication, but now I have images loading and no errors are displayed when trying to watch a channel.

That doesn't seem like fixing some image load errors should have fixed video playback in the TV app, but it just worked.