### PR TITLE
Stop Async connection handler threads if remote host has closed the connection.

### DIFF
--- a/TVHeadEnd/HTSP/HTSConnectionAsync.cs
+++ b/TVHeadEnd/HTSP/HTSConnectionAsync.cs
@@ -384,8 +384,13 @@ namespace TVHeadEnd.HTSP
                 }
                 try
                 {
-                    int bytesReveived = _socket.Receive(readBuffer);
-                    _buffer.appendCount(readBuffer, bytesReveived);
+                    int bytesReceived = _socket.Receive(readBuffer);
+                    if (bytesReceived == 0)
+                    {
+                        stop();
+                        return;
+                    }
+                    _buffer.appendCount(readBuffer, bytesReceived);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes #73 
As far as I can tell, when the socket is in a connection-oriented mode (TCP) and the remote host has closed the connection `Socket.Receive()` will stop blocking and `bytesReceived` will always be `0`.