### PR TITLE
Fix live stream not working with 10.9

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -438,6 +438,7 @@ namespace TVHeadEnd
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
+                livetvasset.AnalyzeDurationMs = 3000;
 
                 // Probe the asset stream to determine available sub-streams
                 string livetvasset_probeUrl = "" + livetvasset.Path;
@@ -465,6 +466,7 @@ namespace TVHeadEnd
                     Id = channelId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
+                    AnalyzeDurationMs = 3000,
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream


### PR DESCRIPTION
Fixed issue where ffmpeg continues to probe live TV Stream by reducing maximal probe time to 3 seconds.