### PR TITLE
Fixed TV Recording channel for 10.9 

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -62,6 +62,7 @@ namespace TVHeadEnd
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<HTSConnectionHandler>();
             _httpClientFactory = httpClientFactory;
+            _liveTvService = null;
 
             //System.Diagnostics.StackTrace t = new System.Diagnostics.StackTrace();
             _logger.LogDebug("[TVHclient] HTSConnectionHandler");
@@ -91,6 +92,11 @@ namespace TVHeadEnd
         public void setLiveTvService(LiveTvService liveTvService)
         {
             _liveTvService = liveTvService;
+        }
+
+        public LiveTvService getLiveTvService()
+        {
+            return _liveTvService;
         }
 
         public int WaitForInitialLoad(CancellationToken cancellationToken)

--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -19,7 +19,7 @@ using TVHeadEnd.HTSP;
 
 namespace TVHeadEnd
 {
-    class HTSConnectionHandler : HTSConnectionListener
+    public class HTSConnectionHandler : HTSConnectionListener
     {
         private static volatile HTSConnectionHandler _instance;
         private static object _syncRoot = new Object();

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -544,30 +544,6 @@ namespace TVHeadEnd
             throw new NotImplementedException();
         }
 
-        public async Task<IEnumerable<MyRecordingInfo>> GetAllRecordingsAsync(CancellationToken cancellationToken)
-        {
-            // retrieve all 'Pending', 'Inprogress' and 'Completed' recordings
-            // we don't deliver the 'Pending' recordings
-
-            int timeOut = await WaitForInitialLoadTask(cancellationToken);
-            if (timeOut == -1 || cancellationToken.IsCancellationRequested)
-            {
-                _logger.LogDebug("[TVHclient] LiveTvService.GetRecordingsAsync: call cancelled or timed out - returning empty list");
-                return new List<MyRecordingInfo>();
-            }
-
-            TaskWithTimeoutRunner<IEnumerable<MyRecordingInfo>> twtr = new TaskWithTimeoutRunner<IEnumerable<MyRecordingInfo>>(TIMEOUT);
-            TaskWithTimeoutResult<IEnumerable<MyRecordingInfo>> twtRes = await
-                twtr.RunWithTimeout(_htsConnectionHandler.BuildDvrInfos(cancellationToken));
-
-            if (twtRes.HasTimeout)
-            {
-                return new List<MyRecordingInfo>();
-            }
-
-            return twtRes.Result;
-        }
-
         private void LogStringList(List<String> theList, String prefix)
         {
             // TODO: Really? doublecheck that this is the way to do it, or if a single call to the logger with everything would be better.

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -40,22 +40,13 @@ namespace TVHeadEnd
         private readonly ILogger<LiveTvService> _logger;
         public DateTime LastRecordingChange = DateTime.MinValue;
 
-        public LiveTvService(ILoggerFactory loggerFactory, IMediaEncoder mediaEncoder, IHttpClientFactory httpClientFactory)
+        public LiveTvService(ILoggerFactory loggerFactory, IMediaEncoder mediaEncoder, IHttpClientFactory httpClientFactory, HTSConnectionHandler connectionHandler)
         {
             //System.Diagnostics.StackTrace t = new System.Diagnostics.StackTrace();
             _logger = loggerFactory.CreateLogger<LiveTvService>();
             _logger.LogDebug("[TVHclient] LiveTvService()");
 
-            if (httpClientFactory == null)
-            {
-                _logger.LogDebug("[TVHclient] httpClientFactory = null");
-            }
-
-            if (_htsConnectionHandler == null)
-            {
-                _htsConnectionHandler = new HTSConnectionHandler(loggerFactory, httpClientFactory);
-            }
-            _htsConnectionHandler = HTSConnectionHandler.GetInstance(loggerFactory, httpClientFactory);
+            _htsConnectionHandler = connectionHandler;
             _htsConnectionHandler.setLiveTvService(this);
 
             {

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -438,6 +438,7 @@ namespace TVHeadEnd
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
+                livetvasset.AnalyzeDurationMs = 3000;
 
                 // Probe the asset stream to determine available sub-streams
                 string livetvasset_probeUrl = "" + livetvasset.Path;
@@ -465,6 +466,7 @@ namespace TVHeadEnd
                     Id = channelId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
+                    AnalyzeDurationMs = 3000,
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -18,7 +18,7 @@ using MediaBrowser.Model.LiveTv;
 
 namespace TVHeadEnd
 {
-    public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISupportsLatestMedia, ISupportsMediaProbe, IHasFolderAttributes
+    public class RecordingsChannel : IChannel, IHasFolderAttributes
     {
         public ILiveTvManager _liveTvManager;
 
@@ -69,7 +69,7 @@ namespace TVHeadEnd
             get { return ChannelParentalRating.GeneralAudience; }
         }
 
-        public string GetCacheKey(string userId)
+        /*public string GetCacheKey(string userId)
         {
             var now = DateTime.UtcNow;
 
@@ -86,7 +86,7 @@ namespace TVHeadEnd
             values.Add(GetService().LastRecordingChange.Ticks.ToString(CultureInfo.InvariantCulture));
 
             return string.Join("-", values.ToArray());
-        }
+        }*/
 
         public InternalChannelFeatures GetChannelFeatures()
         {
@@ -143,15 +143,15 @@ namespace TVHeadEnd
             return _liveTvManager.Services.OfType<LiveTvService>().First();
         }
 
-        public bool CanDelete(BaseItem item)
+        /*public bool CanDelete(BaseItem item)
         {
             return !item.IsFolder;
-        }
+        }*/
 
-        public Task DeleteItem(string id, CancellationToken cancellationToken)
+        /*public Task DeleteItem(string id, CancellationToken cancellationToken)
         {
             return GetService().DeleteRecordingAsync(id, cancellationToken);
-        }
+        }*/
 
         public async Task<IEnumerable<ChannelItemInfo>> GetLatestMedia(ChannelLatestMediaSearch request, CancellationToken cancellationToken)
         {

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -154,7 +154,7 @@ namespace TVHeadEnd
 
         private Task<int> WaitForInitialLoadTask(CancellationToken cancellationToken)
         {
-            return Task.Factory.StartNew<int>(() => _htsConnectionHandler.WaitForInitialLoad(cancellationToken));
+            return Task.Factory.StartNew<int>(() => _htsConnectionHandler.WaitForInitialLoad(cancellationToken), cancellationToken);
         }
         public async Task<IEnumerable<MyRecordingInfo>> GetAllRecordingsAsync(CancellationToken cancellationToken)
         {
@@ -165,7 +165,7 @@ namespace TVHeadEnd
             if (timeOut == -1 || cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("[TVHclient] GetAllRecordingsAsync - Not initialized ");
-                return new List<MyRecordingInfo>();
+                return [];
             }
 
             TaskWithTimeoutRunner<IEnumerable<MyRecordingInfo>> twtr = new TaskWithTimeoutRunner<IEnumerable<MyRecordingInfo>>(TIMEOUT);
@@ -175,7 +175,7 @@ namespace TVHeadEnd
             if (twtRes.HasTimeout)
             {
                 _logger.LogDebug("[TVHclient] GetAllRecordingsAsync - Timeout");
-                return new List<MyRecordingInfo>();
+                return [];
             }
 
             return twtRes.Result;

--- a/TVHeadEnd/ServiceRegistrator.cs
+++ b/TVHeadEnd/ServiceRegistrator.cs
@@ -1,5 +1,5 @@
 using MediaBrowser.Controller;
-using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;

--- a/TVHeadEnd/ServiceRegistrator.cs
+++ b/TVHeadEnd/ServiceRegistrator.cs
@@ -16,6 +16,6 @@ public class ServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddSingleton<HTSConnectionHandler>();
         serviceCollection.AddSingleton<ILiveTvService, LiveTvService>();
-        ///serviceCollection.AddSingleton<IChannel, RecordingsChannel>();
+        serviceCollection.AddSingleton<IChannel, RecordingsChannel>();
     }
 }

--- a/TVHeadEnd/ServiceRegistrator.cs
+++ b/TVHeadEnd/ServiceRegistrator.cs
@@ -14,7 +14,8 @@ public class ServiceRegistrator : IPluginServiceRegistrator
     /// <inheritdoc />
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
+        serviceCollection.AddSingleton<HTSConnectionHandler>();
         serviceCollection.AddSingleton<ILiveTvService, LiveTvService>();
-        serviceCollection.AddSingleton<IChannel, RecordingsChannel>();
+        ///serviceCollection.AddSingleton<IChannel, RecordingsChannel>();
     }
 }


### PR DESCRIPTION
Problem: 
- When registering LiveTvService and RecordingsChannel as Service we get a reference loop

Solution:
- Registered additional Service for HTSConnectionHandler
- Removed initialization of HTSConnectionHandler from LiveTvService
- Changed RecordingsChannel to not use LiveTvService but HTSConnectionHandler directly