### PR TITLE
Tuned some settings for livetv and playing of recordings.

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -429,7 +429,13 @@ namespace TVHeadEnd
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
-                livetvasset.AnalyzeDurationMs = 3000;
+                livetvasset.AnalyzeDurationMs = 2000;
+                livetvasset.SupportsDirectStream = false;
+                livetvasset.RequiresClosing = true;
+                livetvasset.SupportsProbing = false;
+                livetvasset.Container = "mpegts";
+                livetvasset.RequiresOpening = true;
+                livetvasset.IsInfiniteStream  = true;
 
                 // Probe the asset stream to determine available sub-streams
                 string livetvasset_probeUrl = "" + livetvasset.Path;
@@ -457,7 +463,10 @@ namespace TVHeadEnd
                     Id = channelId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
-                    AnalyzeDurationMs = 3000,
+                    AnalyzeDurationMs = 2000,
+                    SupportsDirectStream = false,
+                    SupportsProbing = false,
+                    Container = "mpegts",
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream
@@ -569,6 +578,15 @@ namespace TVHeadEnd
                 // Set asset source and type for stream probing and logging
                 string recordingasset_probeUrl = "" + recordingasset.Path;
 
+                recordingasset.AnalyzeDurationMs = 2000;
+                recordingasset.SupportsDirectStream = false;
+                recordingasset.RequiresClosing = true;
+                recordingasset.SupportsProbing = false;
+                recordingasset.Container = "mpegts";
+                recordingasset.RequiresOpening = true;
+                recordingasset.IsInfiniteStream  = true;
+
+
                 // If enabled, force video deinterlacing for recordings
                 if (_htsConnectionHandler.GetForceDeinterlace())
                 {
@@ -592,6 +610,9 @@ namespace TVHeadEnd
                     Id = recordingId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
+                    AnalyzeDurationMs = 2000,
+                    SupportsDirectStream = false,
+                    Container = "mpegts",
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream


### PR DESCRIPTION
Still not working perfectly.
Issues:
- See some A/V out-of-sync depending on the client.
- Recordings can only be navigated as far as transcoding has progressed within the stream (I had to disabled probing and did not find where to get the length of the recording from TVHeadend side)