### PR TITLE
Further Release 10.9.x improvements

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -429,7 +429,13 @@ namespace TVHeadEnd
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
-                livetvasset.AnalyzeDurationMs = 3000;
+                livetvasset.AnalyzeDurationMs = 2000;
+                livetvasset.SupportsDirectStream = false;
+                livetvasset.RequiresClosing = true;
+                livetvasset.SupportsProbing = false;
+                livetvasset.Container = "mpegts";
+                livetvasset.RequiresOpening = true;
+                livetvasset.IsInfiniteStream  = true;
 
                 // Probe the asset stream to determine available sub-streams
                 string livetvasset_probeUrl = "" + livetvasset.Path;
@@ -457,7 +463,10 @@ namespace TVHeadEnd
                     Id = channelId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
-                    AnalyzeDurationMs = 3000,
+                    AnalyzeDurationMs = 2000,
+                    SupportsDirectStream = false,
+                    SupportsProbing = false,
+                    Container = "mpegts",
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream
@@ -569,6 +578,15 @@ namespace TVHeadEnd
                 // Set asset source and type for stream probing and logging
                 string recordingasset_probeUrl = "" + recordingasset.Path;
 
+                recordingasset.AnalyzeDurationMs = 2000;
+                recordingasset.SupportsDirectStream = false;
+                recordingasset.RequiresClosing = true;
+                recordingasset.SupportsProbing = false;
+                recordingasset.Container = "mpegts";
+                recordingasset.RequiresOpening = true;
+                recordingasset.IsInfiniteStream  = true;
+
+
                 // If enabled, force video deinterlacing for recordings
                 if (_htsConnectionHandler.GetForceDeinterlace())
                 {
@@ -592,6 +610,10 @@ namespace TVHeadEnd
                     Id = recordingId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
+                    AnalyzeDurationMs = 2000,
+                    SupportsDirectStream = false,
+                    SupportsProbing = false,
+                    Container = "mpegts",
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -451,6 +451,7 @@ namespace TVHeadEnd
                         {
                             i.IsInterlaced = true;
                         }
+                        i.RealFrameRate = 50.0F;
                     }
                 }
 
@@ -475,7 +476,8 @@ namespace TVHeadEnd
                             // Set the index to -1 because we don't know the exact index of the video stream within the container
                             Index = -1,
                             // Set to true if unknown to enable deinterlacing
-                            IsInterlaced = true
+                            IsInterlaced = true,
+                            RealFrameRate = 50.0F
                         },
                         new MediaStream
                         {
@@ -622,7 +624,8 @@ namespace TVHeadEnd
                             // Set the index to -1 because we don't know the exact index of the video stream within the container
                             Index = -1,
                             // Set to true if unknown to enable deinterlacing
-                            IsInterlaced = true
+                            IsInterlaced = true,
+                            RealFrameRate = 50.0F
                         },
                         new MediaStream
                         {

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -273,11 +273,9 @@ namespace TVHeadEnd
                 ContentType = item.IsMovie ? ChannelMediaContentType.Movie : (item.IsSeries ? ChannelMediaContentType.Episode : ChannelMediaContentType.Clip),
                 Genres = item.Genres,
                 ImageUrl = item.ImageUrl,
-                //HomePageUrl = item.HomePageUrl
                 Id = item.Id,
-                //IndexNumber = item.IndexNumber,
                 MediaType = item.ChannelType == MediaBrowser.Model.LiveTv.ChannelType.TV ? ChannelMediaType.Video : ChannelMediaType.Audio,
-                IsLiveStream = false, //item.Status == MediaBrowser.Model.LiveTv.RecordingStatus.InProgress,
+                IsLiveStream = false,
                 MediaSources = new List<MediaSourceInfo>
                 {
                     new MediaSourceInfo

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -22,7 +22,7 @@ using TVHeadEnd.TimeoutHelper;
 
 namespace TVHeadEnd
 {
-    public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISupportsLatestMedia, ISupportsMediaProbe, IHasFolderAttributes
+    public class RecordingsChannel : IChannel, ISupportsDelete, ISupportsLatestMedia, IHasFolderAttributes
     {
         private HTSConnectionHandler _htsConnectionHandler;
         private readonly TimeSpan TIMEOUT = TimeSpan.FromMinutes(5);
@@ -246,6 +246,8 @@ namespace TVHeadEnd
 
         public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, Func<MyRecordingInfo, bool> filter, CancellationToken cancellationToken)
         {
+            _logger.LogDebug("[TVHclient] GetChannelItems - Updating TVHeadend Recording Items");
+
             var allRecordings = await GetAllRecordingsAsync(cancellationToken).ConfigureAwait(false);
 
             var result = new ChannelItemResult
@@ -260,6 +262,8 @@ namespace TVHeadEnd
         {
             var path = buildRecordingPath(item.Id);
 
+            _logger.LogDebug("[TVHclient] ConvertToChannelItem - Creating ChannelItemInfo");
+
             var channelItem = new ChannelItemInfo
             {
                 Name = string.IsNullOrEmpty(item.EpisodeTitle) ? item.Name : item.EpisodeTitle,
@@ -273,13 +277,33 @@ namespace TVHeadEnd
                 Id = item.Id,
                 //IndexNumber = item.IndexNumber,
                 MediaType = item.ChannelType == MediaBrowser.Model.LiveTv.ChannelType.TV ? ChannelMediaType.Video : ChannelMediaType.Audio,
+                IsLiveStream = false, //item.Status == MediaBrowser.Model.LiveTv.RecordingStatus.InProgress,
                 MediaSources = new List<MediaSourceInfo>
                 {
                     new MediaSourceInfo
                     {
                         Path = path,
                         Protocol = path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? MediaProtocol.Http : MediaProtocol.File,
-                        Id = item.Id
+                        Id = item.Id,
+                        Container = "mpegts",
+                        AnalyzeDurationMs = 2000,
+                        MediaStreams = new List<MediaStream>
+                        {
+                            new MediaStream
+                            {
+                                Type = MediaStreamType.Video,
+                                // Set the index to -1 because we don't know the exact index of the video stream within the container
+                                Index = -1,
+                                // Set to true if unknown to enable deinterlacing
+                                IsInterlaced = true
+                            },
+                            new MediaStream
+                            {
+                                Type = MediaStreamType.Audio,
+                                // Set the index to -1 because we don't know the exact index of the audio stream within the container
+                                Index = -1
+                            }
+                        }
                     }
                 },
                 //ParentIndexNumber = item.ParentIndexNumber,
@@ -293,7 +317,6 @@ namespace TVHeadEnd
                 DateModified = item.DateLastUpdated,
                 Overview = item.Overview,
                 //People = item.People
-                IsLiveStream = item.Status == MediaBrowser.Model.LiveTv.RecordingStatus.InProgress,
                 Etag = item.Status.ToString()
             };
 
@@ -326,6 +349,8 @@ namespace TVHeadEnd
 
         private async Task<ChannelItemResult> GetRecordingGroups(InternalChannelItemQuery query, CancellationToken cancellationToken)
         {
+            _logger.LogDebug("[TVHclient] GetRecordingGroups - Updateing TVHeadend Recording Items");
+
             var allRecordings = await GetAllRecordingsAsync(cancellationToken).ConfigureAwait(false);
             var result = new ChannelItemResult();
             var items = new List<ChannelItemInfo>();

--- a/TVHeadEnd/RecordingsChannel.cs
+++ b/TVHeadEnd/RecordingsChannel.cs
@@ -293,7 +293,8 @@ namespace TVHeadEnd
                                 // Set the index to -1 because we don't know the exact index of the video stream within the container
                                 Index = -1,
                                 // Set to true if unknown to enable deinterlacing
-                                IsInterlaced = true
+                                IsInterlaced = true,
+                                RealFrameRate = 50.0F
                             },
                             new MediaStream
                             {


### PR DESCRIPTION
This PR improve MediaSourceInfo parameters in order to stabilize the liveTV and Recordings playback experience. 

This PR solves #89. Remark: Client playback setting "Prefer fMP4-HLS Media Container" has to be disabled. Will provide another PR to fix this to the Jellyfin server repo.
