### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/TVHeadEnd/TVHeadEnd.csproj
+++ b/TVHeadEnd/TVHeadEnd.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TVHeadEnd/TVHeadEnd.csproj
+++ b/TVHeadEnd/TVHeadEnd.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
   </ItemGroup>
 
 </Project>

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ guid: "3fd018e5-5e78-4e58-b280-a0c068febee0"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tvheadend.png"
 version: 13
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 owner: "jellyfin"
 overview: "Manage TVHeadend from Jellyfin"
 description: "Manage TVHeadend from Jellyfin"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "TVHeadend"
 guid: "3fd018e5-5e78-4e58-b280-a0c068febee0"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tvheadend.png"
 version: 13
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "Manage TVHeadend from Jellyfin"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "TVHeadend"
 guid: "3fd018e5-5e78-4e58-b280-a0c068febee0"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-tvheadend.png"
 version: 13
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "Manage TVHeadend from Jellyfin"


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.