### PR TITLE
Do not cache failed playback ticket requests

### DIFF
--- a/TVHeadEnd/AccessTicketHandler.cs
+++ b/TVHeadEnd/AccessTicketHandler.cs
@@ -60,7 +60,20 @@ public class AccessTicketHandler
 
         while (_ticketCache.TryGetValue(itemId, out var ticketTask))
         {
-            ticket = await ticketTask;
+            try
+            {
+                ticket = await ticketTask;
+            }
+            catch
+            {
+                // The cached request failed (e.g. TVH unreachable). Drop it so
+                // the next attempt can request a fresh ticket, otherwise this
+                // item could never be played again without a restart.
+                _ticketCache.TryRemove(new KeyValuePair<string, Task<Ticket>>(itemId, ticketTask));
+                ticket = null;
+                break;
+            }
+
             if (ticket.Expires > now)
             {
                 return ticket; // non-expired ticket from cache
@@ -70,7 +83,16 @@ public class AccessTicketHandler
             _ticketCache.TryRemove(new KeyValuePair<string, Task<Ticket>>(itemId, ticketTask));
         }
 
-        return await _ticketCache.GetOrAdd(itemId, _ => GetTicketRecord(itemId, cancellationToken, ticket, now));
+        var newTicketTask = _ticketCache.GetOrAdd(itemId, _ => GetTicketRecord(itemId, cancellationToken, ticket, now));
+        try
+        {
+            return await newTicketTask;
+        }
+        catch
+        {
+            _ticketCache.TryRemove(new KeyValuePair<string, Task<Ticket>>(itemId, newTicketTask));
+            throw;
+        }
     }
 
     private Task<Ticket> GetTicketRecord(string itemId, CancellationToken cancellation, Ticket currentRecord, DateTime now)


### PR DESCRIPTION
**Problem**

`AccessTicketHandler.GetTicket()` caches the `Task<Ticket>` per item in `_ticketCache`. When a ticket request fails (server temporarily unreachable, request timeout, or an unexpected response that makes the continuation in `GetTicketRecord()` throw), the faulted task stays in the cache forever: every later `GetTicket()` call for that item awaits the same faulted task and rethrows. Playback of that channel or recording then stays broken until Jellyfin is restarted, even after the TVHeadend server has fully recovered.

**Changes**

Evict the cached task when it turns out to be faulted, both when it is found in the cache and when it was just created, so the next playback attempt requests a fresh ticket. Successful tickets are cached exactly as before.

Found by code inspection while working on connection failure handling; running on my production setup.
