### PR TITLE
Fail fast when the TVHeadend server is unreachable

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -33,6 +33,21 @@ namespace TVHeadEnd
         private volatile Boolean _initialLoadFinished = false;
         private volatile Boolean _connected = false;
         private volatile Boolean _configured = false;
+        private volatile Boolean _firstConnectAttemptCompleted = false;
+
+        // Give up a single connection attempt after this time (an unreachable
+        // host would otherwise block for the full kernel TCP timeout).
+        private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(10);
+
+        // How long callers may wait for the initial sync while a connection
+        // attempt is in flight or the initial data is still being received.
+        // When the server is known to be unreachable callers fail immediately
+        // and never wait.
+        private static readonly TimeSpan InitialLoadTimeout = TimeSpan.FromMinutes(5);
+
+        private const int MaxRetryDelaySeconds = 60;
+
+        private Task _connectionTask;
 
         private HTSConnectionAsync _htsConnection;
         private int _priority;
@@ -101,19 +116,30 @@ namespace TVHeadEnd
 
         public int WaitForInitialLoad(CancellationToken cancellationToken)
         {
-            ensureConnection();
-            DateTime start = DateTime.Now;
-            while (!_initialLoadFinished || cancellationToken.IsCancellationRequested)
+            StartConnectionLoop();
+            DateTime deadline = DateTime.UtcNow + InitialLoadTimeout;
+            while (!cancellationToken.IsCancellationRequested)
             {
-                Thread.Sleep(500);
-                TimeSpan duration = DateTime.Now - start;
-                long durationInSec = duration.Ticks / TimeSpan.TicksPerSecond;
-                if (durationInSec > 60 * 15) // 15 Min timeout, should be enough to load huge data count
+                if (_initialLoadFinished)
+                {
+                    return 0;
+                }
+
+                // Fail fast while the server is unreachable: the background
+                // loop keeps reconnecting, callers must not block on it.
+                if (_firstConnectAttemptCompleted && !_connected)
                 {
                     return -1;
                 }
+
+                if (DateTime.UtcNow > deadline)
+                {
+                    return -1;
+                }
+
+                Thread.Sleep(100);
             }
-            return 0;
+            return -1;
         }
 
         private void init()
@@ -224,64 +250,115 @@ namespace TVHeadEnd
         //    return stream;
         //}
 
-        private void ensureConnection()
+        private void StartConnectionLoop()
         {
             init();
 
-            //_logger.LogDebug("[TVHclient] HTSConnectionHandler.ensureConnection");
-            if (_htsConnection == null || _htsConnection.needsRestart())
-            {
-                _logger.LogDebug("[TVHclient] HTSConnectionHandler.ensureConnection: create new HTS connection");
-                Version version = Assembly.GetEntryAssembly().GetName().Version;
-                _htsConnection = new HTSConnectionAsync(this, "TVHclient4Emby-" + version.ToString(), "" + HTSMessage.HTSP_VERSION, _loggerFactory);
-                _connected = false;
-            }
-
             lock (_lock)
             {
-                if (!_connected)
+                if (_connected || (_connectionTask != null && !_connectionTask.IsCompleted))
                 {
-                    _logger.LogDebug("[TVHclient] HTSConnectionHandler.ensureConnection: used connection parameters: " +
+                    return;
+                }
+
+                _connectionTask = Task.Run(() => ConnectionLoop());
+            }
+        }
+
+        private async Task ConnectionLoop()
+        {
+            int attempt = 0;
+            while (!_connected)
+            {
+                try
+                {
+                    HTSConnectionAsync connection;
+                    lock (_lock)
+                    {
+                        if (_htsConnection == null || _htsConnection.needsRestart())
+                        {
+                            _logger.LogDebug("[TVHclient] HTSConnectionHandler.ConnectionLoop: create new HTS connection");
+                            Version version = Assembly.GetEntryAssembly().GetName().Version;
+                            _htsConnection = new HTSConnectionAsync(this, "TVHclient4Emby-" + version.ToString(), "" + HTSMessage.HTSP_VERSION, _loggerFactory);
+                        }
+                        connection = _htsConnection;
+                    }
+
+                    _logger.LogDebug("[TVHclient] HTSConnectionHandler.ConnectionLoop: used connection parameters: " +
                         "TVH Server = '{servername}'; HTTP Port = '{httpport}'; HTSP Port = '{htspport}'; Web-Root = '{webroot}'; " +
                         "User = '{user}'; Password set = '{passexists}'",
                         _tvhServerName, _httpPort, _htspPort, _webRoot, _userName, (_password.Length > 0));
 
-                    _htsConnection.open(_tvhServerName, _htspPort);
-                    _connected = _htsConnection.authenticate(_userName, _password);
+                    connection.open(_tvhServerName, _htspPort, ConnectTimeout);
 
-                    _logger.LogDebug("[TVHclient] HTSConnectionHandler.ensureConnection: connection established {c}", _connected);
+                    if (connection.authenticate(_userName, _password))
+                    {
+                        _connected = true;
+                        _logger.LogInformation("[TVHclient] HTSConnectionHandler.ConnectionLoop: connection to {servername}:{htspport} established",
+                            _tvhServerName, _htspPort);
+                        return;
+                    }
+
+                    _logger.LogError("[TVHclient] HTSConnectionHandler.ConnectionLoop: authentication failed");
+                    connection.stop();
                 }
+                catch (Exception ex)
+                {
+                    _logger.LogError("[TVHclient] HTSConnectionHandler.ConnectionLoop: can't connect to {servername}:{htspport} - {message}",
+                        _tvhServerName, _htspPort, ex.Message);
+                }
+                finally
+                {
+                    _firstConnectAttemptCompleted = true;
+                }
+
+                attempt++;
+                int delaySeconds = Math.Min(MaxRetryDelaySeconds, 5 << Math.Min(attempt - 1, 4));
+                _logger.LogDebug("[TVHclient] HTSConnectionHandler.ConnectionLoop: next connection attempt in {delay}s", delaySeconds);
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds)).ConfigureAwait(false);
             }
         }
 
         public void SendMessage(HTSMessage message, HTSResponseHandler responseHandler)
         {
-            ensureConnection();
-            _htsConnection.sendMessage(message, responseHandler);
+            StartConnectionLoop();
+
+            HTSConnectionAsync connection = _htsConnection;
+            if (!_connected || connection == null)
+            {
+                throw new InvalidOperationException("[TVHclient] HTSConnectionHandler.SendMessage: not connected to TVH server '"
+                    + _tvhServerName + ":" + _htspPort + "'");
+            }
+
+            connection.sendMessage(message, responseHandler);
         }
 
         public String GetServername()
         {
-            ensureConnection();
-            return _htsConnection.getServername();
+            StartConnectionLoop();
+            HTSConnectionAsync connection = _htsConnection;
+            return (_connected && connection != null) ? connection.getServername() : null;
         }
 
         public String GetServerVersion()
         {
-            ensureConnection();
-            return _htsConnection.getServerversion();
+            StartConnectionLoop();
+            HTSConnectionAsync connection = _htsConnection;
+            return (_connected && connection != null) ? connection.getServerversion() : null;
         }
 
         public int GetServerProtocolVersion()
         {
-            ensureConnection();
-            return _htsConnection.getServerProtocolVersion();
+            StartConnectionLoop();
+            HTSConnectionAsync connection = _htsConnection;
+            return (_connected && connection != null) ? connection.getServerProtocolVersion() : -1;
         }
 
         public String GetDiskSpace()
         {
-            ensureConnection();
-            return _htsConnection.getDiskspace();
+            StartConnectionLoop();
+            HTSConnectionAsync connection = _htsConnection;
+            return (_connected && connection != null) ? connection.getDiskspace() : null;
         }
 
         public Task<IEnumerable<ChannelInfo>> BuildChannelInfos(CancellationToken cancellationToken)
@@ -337,11 +414,18 @@ namespace TVHeadEnd
         public void onError(Exception ex)
         {
             _logger.LogError(ex, "[TVHclient] HTSConnectionHandler: HTSP error");
-            _htsConnection.stop();
-            _htsConnection = null;
-            _connected = false;
+            lock (_lock)
+            {
+                if (_htsConnection != null)
+                {
+                    _htsConnection.stop();
+                    _htsConnection = null;
+                }
+                _connected = false;
+                _initialLoadFinished = false;
+            }
             //_liveTvService.sendDataSourceChanged();
-            ensureConnection();
+            StartConnectionLoop();
         }
 
         public void onMessage(HTSMessage response)

--- a/TVHeadEnd/HTSP/HTSConnectionAsync.cs
+++ b/TVHeadEnd/HTSP/HTSConnectionAsync.cs
@@ -14,6 +14,10 @@ namespace TVHeadEnd.HTSP
     {
         private const long BytesPerGiga = 1024 * 1024 * 1024;
 
+        // Bounded wait for handshake responses so that a connection dying
+        // during the handshake can't block the caller forever.
+        private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(20);
+
         private volatile Boolean _needsRestart = false;
         private volatile Boolean _connected;
         private volatile int _seq = 0;
@@ -116,7 +120,7 @@ namespace TVHeadEnd.HTSP
             return _needsRestart;
         }
 
-        public void open(String hostname, int port)
+        public void open(String hostname, int port, TimeSpan connectTimeout)
         {
             if (_connected)
             {
@@ -124,63 +128,72 @@ namespace TVHeadEnd.HTSP
             }
 
             Monitor.Enter(_lock);
-            while (!_connected)
+            try
             {
-                try
+                // Establish the remote endpoint for the socket.
+
+                IPAddress ipAddress;
+                if (!IPAddress.TryParse(hostname, out ipAddress))
                 {
-                    // Establish the remote endpoint for the socket.
-
-                    IPAddress ipAddress;
-                    if (!IPAddress.TryParse(hostname, out ipAddress))
-                    {
-                        // no IP --> ask DNS
-                        IPHostEntry ipHostInfo = Dns.GetHostEntry(hostname);
-                        ipAddress = ipHostInfo.AddressList[0];
-                    }
-
-                    IPEndPoint remoteEP = new IPEndPoint(ipAddress, port);
-
-                    _logger.LogDebug("[TVHclient] HTSConnectionAsync.open: IPEndPoint = '{IP}'; AddressFamily = '{AF}'",
-                        remoteEP.ToString(), ipAddress.AddressFamily);
-
-                    // Create a TCP/IP  socket.
-                    _socket = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-                    // connect to server
-                    _socket.Connect(remoteEP);
-
-                    _connected = true;
-                    _logger.LogDebug("[TVHclient] HTSConnectionAsync.open: socket connected");
+                    // no IP --> ask DNS
+                    IPHostEntry ipHostInfo = Dns.GetHostEntry(hostname);
+                    ipAddress = ipHostInfo.AddressList[0];
                 }
-                catch (Exception ex)
+
+                IPEndPoint remoteEP = new IPEndPoint(ipAddress, port);
+
+                _logger.LogDebug("[TVHclient] HTSConnectionAsync.open: IPEndPoint = '{IP}'; AddressFamily = '{AF}'",
+                    remoteEP.ToString(), ipAddress.AddressFamily);
+
+                // Create a TCP/IP  socket.
+                _socket = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+                // Detect a silently dead peer (e.g. remote server or VPN link
+                // gone away without RST/FIN) within ~90s instead of blocking
+                // in Receive() forever.
+                _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                _socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
+                _socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 10);
+                _socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 3);
+
+                // Connect to the server, but never wait longer than connectTimeout:
+                // when the host is unreachable a plain Connect() blocks for the
+                // full kernel TCP timeout (about 2 minutes on Linux).
+                IAsyncResult connectResult = _socket.BeginConnect(remoteEP, null, null);
+                if (!connectResult.AsyncWaitHandle.WaitOne(connectTimeout, true))
                 {
-                    _logger.LogError(ex, "[TVHclient] HTSConnectionAsync.open: exception caught");
-
-                    Thread.Sleep(2000);
+                    _socket.Close();
+                    throw new TimeoutException("No response from '" + remoteEP + "' within " + connectTimeout.TotalSeconds + "s");
                 }
+                _socket.EndConnect(connectResult);
+
+                _connected = true;
+                _logger.LogDebug("[TVHclient] HTSConnectionAsync.open: socket connected");
+
+                ThreadStart ReceiveHandlerRef = new ThreadStart(ReceiveHandler);
+                _receiveHandlerThread = new Thread(ReceiveHandlerRef);
+                _receiveHandlerThread.IsBackground = true;
+                _receiveHandlerThread.Start();
+
+                ThreadStart MessageBuilderRef = new ThreadStart(MessageBuilder);
+                _messageBuilderThread = new Thread(MessageBuilderRef);
+                _messageBuilderThread.IsBackground = true;
+                _messageBuilderThread.Start();
+
+                ThreadStart SendingHandlerRef = new ThreadStart(SendingHandler);
+                _sendingHandlerThread = new Thread(SendingHandlerRef);
+                _sendingHandlerThread.IsBackground = true;
+                _sendingHandlerThread.Start();
+
+                ThreadStart MessageDistributorRef = new ThreadStart(MessageDistributor);
+                _messageDistributorThread = new Thread(MessageDistributorRef);
+                _messageDistributorThread.IsBackground = true;
+                _messageDistributorThread.Start();
             }
-
-            ThreadStart ReceiveHandlerRef = new ThreadStart(ReceiveHandler);
-            _receiveHandlerThread = new Thread(ReceiveHandlerRef);
-            _receiveHandlerThread.IsBackground = true;
-            _receiveHandlerThread.Start();
-
-            ThreadStart MessageBuilderRef = new ThreadStart(MessageBuilder);
-            _messageBuilderThread = new Thread(MessageBuilderRef);
-            _messageBuilderThread.IsBackground = true;
-            _messageBuilderThread.Start();
-
-            ThreadStart SendingHandlerRef = new ThreadStart(SendingHandler);
-            _sendingHandlerThread = new Thread(SendingHandlerRef);
-            _sendingHandlerThread.IsBackground = true;
-            _sendingHandlerThread.Start();
-
-            ThreadStart MessageDistributorRef = new ThreadStart(MessageDistributor);
-            _messageDistributorThread = new Thread(MessageDistributorRef);
-            _messageDistributorThread.IsBackground = true;
-            _messageDistributorThread.Start();
-
-            Monitor.Exit(_lock);
+            finally
+            {
+                Monitor.Exit(_lock);
+            }
         }
 
         public Boolean authenticate(String username, String password)
@@ -196,7 +209,7 @@ namespace TVHeadEnd.HTSP
 
             LoopBackResponseHandler loopBackResponseHandler = new LoopBackResponseHandler();
             sendMessage(helloMessage, loopBackResponseHandler);
-            HTSMessage helloResponse = loopBackResponseHandler.getResponse();
+            HTSMessage helloResponse = loopBackResponseHandler.getResponse(ResponseTimeout);
             if (helloResponse != null)
             {
                 if (helloResponse.containsField("htspversion"))
@@ -246,7 +259,7 @@ namespace TVHeadEnd.HTSP
                 authMessage.putField("username", username);
                 authMessage.putField("digest", digest);
                 sendMessage(authMessage, loopBackResponseHandler);
-                HTSMessage authResponse = loopBackResponseHandler.getResponse();
+                HTSMessage authResponse = loopBackResponseHandler.getResponse(ResponseTimeout);
                 if (authResponse != null)
                 {
                     Boolean auth = authResponse.getInt("noaccess", 0) != 1;
@@ -255,7 +268,7 @@ namespace TVHeadEnd.HTSP
                         HTSMessage getDiskSpaceMessage = new HTSMessage();
                         getDiskSpaceMessage.Method = "getDiskSpace";
                         sendMessage(getDiskSpaceMessage, loopBackResponseHandler);
-                        HTSMessage diskSpaceResponse = loopBackResponseHandler.getResponse();
+                        HTSMessage diskSpaceResponse = loopBackResponseHandler.getResponse(ResponseTimeout);
                         if (diskSpaceResponse != null)
                         {
                             long freeDiskSpace = -1;

--- a/TVHeadEnd/HTSP_Responses/LoopBackResponseHandler.cs
+++ b/TVHeadEnd/HTSP_Responses/LoopBackResponseHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using TVHeadEnd.Helper;
 using TVHeadEnd.HTSP;
 
@@ -20,6 +21,12 @@ namespace TVHeadEnd.HTSP_Responses
         public HTSMessage getResponse()
         {
             return _responseDataQueue.Dequeue();
+        }
+
+        public HTSMessage getResponse(TimeSpan timeout)
+        {
+            HTSMessage response;
+            return _responseDataQueue.TryDequeue(out response, timeout) ? response : null;
         }
     }
 }

--- a/TVHeadEnd/Helper/SizeQueue.cs
+++ b/TVHeadEnd/Helper/SizeQueue.cs
@@ -45,5 +45,30 @@ namespace TVHeadEnd.Helper
                 return item;
             }
         }
+
+        public bool TryDequeue(out T item, TimeSpan timeout)
+        {
+            DateTime deadline = DateTime.UtcNow + timeout;
+            lock (_queue)
+            {
+                while (_queue.Count == 0)
+                {
+                    TimeSpan remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        item = default(T);
+                        return false;
+                    }
+                    Monitor.Wait(_queue, remaining);
+                }
+                item = _queue.Dequeue();
+                if (_queue.Count == _maxSize - 1)
+                {
+                    // wake up any blocked enqueue
+                    Monitor.PulseAll(_queue);
+                }
+                return true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #101
Fixes #66

**Problem**

When the TVHeadend server is unreachable, large parts of the Jellyfin web UI (home screen, anything touching Live TV or the Recordings channel) spin for minutes and then fail to load:

1. `HTSConnectionAsync.open()` retries a synchronous `Socket.Connect()` in an infinite loop. When the host is silently unreachable each attempt blocks for the full kernel TCP timeout (about 2 minutes on Linux); when the connection is refused it retries every 2 seconds forever (the log excerpt in #101 shows this).
2. Because the connection never comes up, `initialSyncCompleted` never arrives, so every LiveTV call sits in `WaitForInitialLoad()` until its timeout while requests like `/LiveTv/Programs/Recommended` hang.

**Changes**

- Connection establishment moves into a single background loop with a 10s connect timeout and exponential backoff (5s up to a 60s cap) instead of being performed synchronously inside API calls. The plugin reconnects automatically once the server is reachable again.
- `WaitForInitialLoad()` returns immediately when the server is known to be unreachable. Callers already handle the -1 result by returning empty lists, so the UI loads normally and Live TV simply shows no data while the server is down. Only the very first attempt after startup is awaited (bounded by the connect timeout) so that a reachable server does not come up with an empty channel list.
- `SendMessage()` throws instead of blocking when there is no connection, so playback attempts fail promptly instead of hanging.
- Handshake responses (`hello`, `authenticate`, `getDiskSpace`) are awaited with a bounded timeout so a connection dying mid-handshake cannot block the connection loop forever.
- TCP keepalive on the HTSP socket detects a silently dead peer (server or VPN link gone without RST/FIN) within about 90 seconds. Previously such a connection stayed "connected" indefinitely while requests waited on responses that could never arrive.
- The initial-load flag is reset on connection loss so stale state cannot make callers wait on a dead connection.

Behaviour with a reachable server is unchanged. I kept the existing threading and polling style of the code base to keep the diff reviewable.

**Testing**

Tested on a production setup (Jellyfin 10.11.11, remote TVHeadend over WireGuard) while the TVHeadend host is unreachable with SYNs silently dropped, which is the worst case.

Before, one attempt roughly every 135 seconds, each one blocking callers for its full duration, repeating all day:

```
[00:01:08] [ERR] [TVHclient] HTSConnectionAsync.open: exception caught
System.Net.Sockets.SocketException (110): Connection timed out 192.168.90.8:9982
   at System.Net.Sockets.Socket.DoConnect(EndPoint endPointSnapshot, SocketAddress socketAddress)
   at System.Net.Sockets.Socket.Connect(EndPoint remoteEP)
   at TVHeadEnd.HTSP.HTSConnectionAsync.open(String hostname, Int32 port)
[00:03:23] [ERR] [TVHclient] HTSConnectionAsync.open: exception caught
...
```

After, bounded attempts with backoff in the background; the dashboard and home screen load instantly with Live TV empty:

```
[23:17:30] [ERR] [TVHclient] HTSConnectionHandler.ConnectionLoop: can't connect to 192.168.90.8:9982 - No response from '192.168.90.8:9982' within 10s
[23:17:50] [ERR] [TVHclient] HTSConnectionHandler.ConnectionLoop: can't connect to 192.168.90.8:9982 - No response from '192.168.90.8:9982' within 10s
[23:18:20] [ERR] [TVHclient] HTSConnectionHandler.ConnectionLoop: can't connect to 192.168.90.8:9982 - No response from '192.168.90.8:9982' within 10s
[23:18:50] ... (backoff continues to one attempt per 70s)
```

The reconnect path reuses the existing `needsRestart()`/new-connection logic; I will confirm reconnection on the same setup once the remote server is back online and report here.

Related: the playback ticket cache had a separate recovery bug that kept playback broken after the server returned, fixed in #115.
