### PR TITLE
Fix TVHeadend recording scheduling integration:

### DIFF
--- a/TVHeadEnd/DataHelper/AutorecDataHelper.cs
+++ b/TVHeadEnd/DataHelper/AutorecDataHelper.cs
@@ -13,8 +13,6 @@ namespace TVHeadEnd.DataHelper
         private readonly ILogger<AutorecDataHelper> _logger;
         private readonly Dictionary<string, HTSMessage> _data;
 
-        private readonly DateTime _initialDateTimeUTC = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         public AutorecDataHelper(ILogger<AutorecDataHelper> logger)
         {
             _logger = logger;
@@ -91,7 +89,11 @@ namespace TVHeadEnd.DataHelper
                         }
 
                         HTSMessage m = entry.Value;
-                        SeriesTimerInfo sti = new SeriesTimerInfo();
+                        SeriesTimerInfo sti = new SeriesTimerInfo
+                        {
+                            RecordAnyChannel = true,
+                            RecordAnyTime = true
+                        };
 
                         try
                         {
@@ -100,8 +102,9 @@ namespace TVHeadEnd.DataHelper
                                 sti.Id = m.getString("id");
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "id", entry.Key);
                         }
 
                         try
@@ -112,32 +115,50 @@ namespace TVHeadEnd.DataHelper
                                 sti.Days = getDayOfWeekListFromInt(daysOfWeek);
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "daysOfWeek", entry.Key);
                         }
 
-                        sti.StartDate = DateTime.Now.ToUniversalTime();
+                        sti.StartDate = DateTime.UtcNow;
+                        sti.EndDate = sti.StartDate;
+
+                        // TVHeadend's retention field is the lifetime of completed
+                        // recordings. SeriesTimerInfo has no equivalent property;
+                        // EndDate instead represents the end of the daily match window.
 
                         try
                         {
-                            if (m.containsField("retention"))
+                            if (m.containsField("start"))
                             {
-                                int retentionInDays = m.getInt("retention");
-
-                                if (DateTime.MaxValue.AddDays(-retentionInDays) < DateTime.Now)
+                                int startMinutes = m.getInt("start");
+                                if (startMinutes >= 0)
                                 {
-                                    _logger.LogError("[TVHclient] AutorecDataHelper.buildAutorecInfos: change during 'EndDate' calculation: set retention value from '{days}' to '365' days", retentionInDays);
-                                    sti.EndDate = DateTime.Now.AddDays(365).ToUniversalTime();
+                                    int endMinutes = m.getInt("startWindow", startMinutes);
+                                    sti.StartDate = DateTime.Today.AddMinutes(startMinutes).ToUniversalTime();
+                                    sti.EndDate = DateTime.Today.AddMinutes(endMinutes).ToUniversalTime();
+                                    // A window whose end is earlier than its start wraps across midnight.
+                                    if (sti.EndDate < sti.StartDate)
+                                    {
+                                        sti.EndDate = sti.EndDate.AddDays(1);
+                                    }
+
+                                    sti.RecordAnyTime = false;
                                 }
                                 else
                                 {
-                                    sti.EndDate = DateTime.Now.AddDays(retentionInDays).ToUniversalTime();
+                                    sti.RecordAnyTime = true;
                                 }
                             }
+                            else
+                            {
+                                sti.RecordAnyTime = true;
+                            }
                         }
-                        catch (Exception e)
+                        catch (InvalidCastException ex)
                         {
-                            _logger.LogError(e, "[TVHclient] AutorecDataHelper.buildAutorecInfos: exception during 'EndDate' calculation. HTSMessage: {m}", m.ToString());
+                            sti.RecordAnyTime = true;
+                            logInvalidField(ex, "start/startWindow", entry.Key);
                         }
 
                         try
@@ -145,10 +166,17 @@ namespace TVHeadEnd.DataHelper
                             if (m.containsField("channel"))
                             {
                                 sti.ChannelId = "" + m.getInt("channel");
+                                sti.RecordAnyChannel = false;
+                            }
+                            else
+                            {
+                                sti.RecordAnyChannel = true;
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            sti.RecordAnyChannel = true;
+                            logInvalidField(ex, "channel", entry.Key);
                         }
 
                         try
@@ -159,8 +187,9 @@ namespace TVHeadEnd.DataHelper
                                 sti.IsPrePaddingRequired = true;
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "startExtra", entry.Key);
                         }
 
                         try
@@ -171,19 +200,25 @@ namespace TVHeadEnd.DataHelper
                                 sti.IsPostPaddingRequired = true;
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "stopExtra", entry.Key);
                         }
 
                         try
                         {
-                            if (m.containsField("title"))
+                            if (m.containsField("name"))
+                            {
+                                sti.Name = m.getString("name");
+                            }
+                            else if (m.containsField("title"))
                             {
                                 sti.Name = m.getString("title");
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "name/title", entry.Key);
                         }
 
                         try
@@ -193,8 +228,9 @@ namespace TVHeadEnd.DataHelper
                                 sti.Overview = m.getString("description");
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "description", entry.Key);
                         }
 
                         try
@@ -204,27 +240,46 @@ namespace TVHeadEnd.DataHelper
                                 sti.Priority = m.getInt("priority");
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "priority", entry.Key);
                         }
 
                         try
                         {
-                            if (m.containsField("title"))
+                            if (m.containsField("serieslinkUri"))
                             {
-                                sti.SeriesId = m.getString("title");
+                                sti.SeriesId = m.getString("serieslinkUri");
                             }
                         }
-                        catch (InvalidCastException)
+                        catch (InvalidCastException ex)
                         {
+                            logInvalidField(ex, "serieslinkUri", entry.Key);
                         }
 
-                        /*
-                                public string ProgramId { get; set; }
-                                public bool RecordAnyChannel { get; set; }
-                                public bool RecordAnyTime { get; set; }
-                                public bool RecordNewOnly { get; set; }
-                         */
+                        try
+                        {
+                            if (m.containsField("dupDetect"))
+                            {
+                                sti.RecordNewOnly = m.getInt("dupDetect") != 0;
+                            }
+                        }
+                        catch (InvalidCastException ex)
+                        {
+                            logInvalidField(ex, "dupDetect", entry.Key);
+                        }
+
+                        try
+                        {
+                            if (m.containsField("maxCount"))
+                            {
+                                sti.KeepUpTo = m.getInt("maxCount");
+                            }
+                        }
+                        catch (InvalidCastException ex)
+                        {
+                            logInvalidField(ex, "maxCount", entry.Key);
+                        }
 
                         result.Add(sti);
                     }
@@ -232,6 +287,15 @@ namespace TVHeadEnd.DataHelper
                     return result;
                 }
             });
+        }
+
+        private void logInvalidField(InvalidCastException exception, string fieldName, string autorecId)
+        {
+            _logger.LogWarning(
+                exception,
+                "[TVHclient] AutorecDataHelper.buildAutorecInfos: could not read field '{field}' for autorecord entry '{id}'",
+                fieldName,
+                autorecId);
         }
 
         private List<DayOfWeek> getDayOfWeekListFromInt(int daysOfWeek)
@@ -303,9 +367,9 @@ namespace TVHeadEnd.DataHelper
 
         public static int getMinutesFromMidnight(DateTime time)
         {
-            DateTime utcTime = time.ToUniversalTime();
-            int hours = utcTime.Hour;
-            int minute = utcTime.Minute;
+            DateTime localTime = time.ToLocalTime();
+            int hours = localTime.Hour;
+            int minute = localTime.Minute;
             int minutes = (hours * 60) + minute;
             return minutes;
         }

--- a/TVHeadEnd/HTSP_Responses/GetEventsResponseHandler.cs
+++ b/TVHeadEnd/HTSP_Responses/GetEventsResponseHandler.cs
@@ -98,9 +98,9 @@ namespace TVHeadEnd.HTSP_Responses
                         pi.Id = "" + currEventMessage.getInt("eventId");
                     }
 
-                    if (currEventMessage.containsField("serieslinkId"))
+                    if (currEventMessage.containsField("serieslinkUri"))
                     {
-                        pi.SeriesId = "" + currEventMessage.getInt("serieslinkId");
+                        pi.SeriesId = currEventMessage.getString("serieslinkUri");
                     }
 
                     if (currEventMessage.containsField("episodeNumber"))

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.LiveTv;
@@ -11,6 +12,7 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
 using Microsoft.Extensions.Logging;
+using TVHeadEnd.DataHelper;
 using TVHeadEnd.Helper;
 using TVHeadEnd.HTSP;
 using TVHeadEnd.HTSP_Responses;
@@ -19,7 +21,7 @@ using static TVHeadEnd.AccessTicketHandler.TicketType;
 
 namespace TVHeadEnd
 {
-    public class LiveTvService : ILiveTvService
+    public class LiveTvService : ILiveTvService, ISupportsNewTimerIds
     {
         private readonly IMediaEncoder _mediaEncoder;
 
@@ -154,24 +156,110 @@ namespace TVHeadEnd
 
         public async Task CreateSeriesTimerAsync(SeriesTimerInfo info, CancellationToken cancellationToken)
         {
-            // Dummy method to avoid warnings
-            await Task.Factory.StartNew(() => 0, cancellationToken);
+            await CreateSeriesTimer(info, cancellationToken);
+        }
 
-            throw new NotImplementedException();
+        public Task<string> CreateSeriesTimer(SeriesTimerInfo info, CancellationToken cancellationToken)
+        {
+            return SaveSeriesTimerAsync(info, "addAutorecEntry", cancellationToken);
+        }
+
+        private async Task<string> SaveSeriesTimerAsync(SeriesTimerInfo info, string method, CancellationToken cancellationToken)
+        {
+            int timeOut = await WaitForInitialLoadTask(cancellationToken);
+            if (timeOut == -1 || cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("LiveTvService.SaveSeriesTimerAsync: call cancelled or timed out");
+                return null;
+            }
+
+            HTSMessage seriesTimerMessage = new HTSMessage();
+            seriesTimerMessage.Method = method;
+
+            if (method == "updateAutorecEntry")
+            {
+                seriesTimerMessage.putField("id", info.Id);
+            }
+
+            // TVHeadend treats an autorec title as a regular expression. Escaping it
+            // prevents punctuation in a programme title from changing what is matched.
+            seriesTimerMessage.putField("title", Regex.Escape(info.Name));
+            seriesTimerMessage.putField("name", info.Name);
+            if (!string.IsNullOrEmpty(info.SeriesId))
+            {
+                seriesTimerMessage.putField("serieslinkUri", info.SeriesId);
+            }
+
+            if (!info.RecordAnyChannel && !string.IsNullOrEmpty(info.ChannelId))
+            {
+                seriesTimerMessage.putField("channelId", Convert.ToInt32(info.ChannelId));
+            }
+
+            seriesTimerMessage.putField("startExtra", (long)(info.PrePaddingSeconds / 60));
+            seriesTimerMessage.putField("stopExtra", (long)(info.PostPaddingSeconds / 60));
+            seriesTimerMessage.putField("enabled", 1);
+            seriesTimerMessage.putField("priority", _htsConnectionHandler.GetPriority());
+            seriesTimerMessage.putField("configName", _htsConnectionHandler.GetProfile());
+            seriesTimerMessage.putField("daysOfWeek", AutorecDataHelper.getDaysOfWeekFromList(info.Days));
+            seriesTimerMessage.putField("dupDetect", info.RecordNewOnly ? 14 : 0);
+            seriesTimerMessage.putField("maxCount", info.KeepUpTo);
+
+            if (info.RecordAnyTime)
+            {
+                seriesTimerMessage.putField("start", -1);
+                seriesTimerMessage.putField("startWindow", -1);
+            }
+            else
+            {
+                seriesTimerMessage.putField("start", AutorecDataHelper.getMinutesFromMidnight(info.StartDate));
+                seriesTimerMessage.putField("startWindow", AutorecDataHelper.getMinutesFromMidnight(info.EndDate));
+            }
+
+            TaskWithTimeoutRunner<HTSMessage> twtr = new TaskWithTimeoutRunner<HTSMessage>(_timeout);
+            TaskWithTimeoutResult<HTSMessage> twtRes = await twtr.RunWithTimeout(Task.Factory.StartNew(() =>
+            {
+                LoopBackResponseHandler lbrh = new LoopBackResponseHandler();
+                _htsConnectionHandler.SendMessage(seriesTimerMessage, lbrh);
+                _lastRecordingChange = DateTime.UtcNow;
+                return lbrh.getResponse();
+            }, cancellationToken));
+
+            if (twtRes.HasTimeout)
+            {
+                throw new TimeoutException("TVHeadend timed out while saving the series timer");
+            }
+
+            HTSMessage response = twtRes.Result;
+            if (response.getInt("success", 0) != 1)
+            {
+                string reason = response.getString("error", response.getString("noaccess", "Unknown TVHeadend error"));
+                throw new InvalidOperationException($"TVHeadend could not save the series timer: {reason}");
+            }
+
+            return response.getString("id", null);
         }
 
         public async Task CreateTimerAsync(TimerInfo info, CancellationToken cancellationToken)
+        {
+            await CreateTimer(info, cancellationToken);
+        }
+
+        public async Task<string> CreateTimer(TimerInfo info, CancellationToken cancellationToken)
         {
             int timeOut = await WaitForInitialLoadTask(cancellationToken);
             if (timeOut == -1 || cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("LiveTvService.CreateTimerAsync: call cancelled or timed out");
-                return;
+                return null;
             }
 
             HTSMessage createTimerMessage = new HTSMessage();
             createTimerMessage.Method = "addDvrEntry";
-            createTimerMessage.putField("channelId", info.ChannelId);
+            createTimerMessage.putField("channelId", Convert.ToInt32(info.ChannelId));
+            if (!string.IsNullOrEmpty(info.ProgramId))
+            {
+                createTimerMessage.putField("eventId", Convert.ToInt32(info.ProgramId));
+            }
             createTimerMessage.putField("start", DateTimeHelper.getUnixUTCTimeFromUtcDateTime(info.StartDate));
             createTimerMessage.putField("stop", DateTimeHelper.getUnixUTCTimeFromUtcDateTime(info.EndDate));
             createTimerMessage.putField("startExtra", (long)(info.PrePaddingSeconds / 60));
@@ -187,29 +275,23 @@ namespace TVHeadEnd
             {
                 LoopBackResponseHandler lbrh = new LoopBackResponseHandler();
                 _htsConnectionHandler.SendMessage(createTimerMessage, lbrh);
+                _lastRecordingChange = DateTime.UtcNow;
                 return lbrh.getResponse();
             }, cancellationToken));
 
             if (twtRes.HasTimeout)
             {
-                _logger.LogError("LiveTvService.CreateTimerAsync: can't create timer because the timeout was reached");
+                throw new TimeoutException("TVHeadend timed out while creating the timer");
             }
-            else
+
+            HTSMessage createTimerResponse = twtRes.Result;
+            if (createTimerResponse.getInt("success", 0) != 1)
             {
-                HTSMessage createTimerResponse = twtRes.Result;
-                Boolean success = createTimerResponse.getInt("success", 0) == 1;
-                if (!success)
-                {
-                    if (createTimerResponse.containsField("error"))
-                    {
-                        _logger.LogError("LiveTvService.CreateTimerAsync: can't create timer: '{why}'", createTimerResponse.getString("error"));
-                    }
-                    else if (createTimerResponse.containsField("noaccess"))
-                    {
-                        _logger.LogError("LiveTvService.CreateTimerAsync: can't create timer: '{why}'", createTimerResponse.getString("noaccess"));
-                    }
-                }
+                string reason = createTimerResponse.getString("error", createTimerResponse.getString("noaccess", "Unknown TVHeadend error"));
+                throw new InvalidOperationException($"TVHeadend could not create the timer: {reason}");
             }
+
+            return createTimerResponse.getString("id", null);
         }
 
         public async Task DeleteRecordingAsync(string recordingId, CancellationToken cancellationToken)
@@ -515,8 +597,8 @@ namespace TVHeadEnd
             {
                 return new SeriesTimerInfo
                 {
-                    PostPaddingSeconds = Plugin.Instance.Configuration.Pre_Padding,
-                    PrePaddingSeconds = Plugin.Instance.Configuration.Post_Padding,
+                    PostPaddingSeconds = Plugin.Instance.Configuration.Post_Padding,
+                    PrePaddingSeconds = Plugin.Instance.Configuration.Pre_Padding,
                     RecordAnyChannel = true,
                     RecordAnyTime = true,
                     RecordNewOnly = false
@@ -606,10 +688,7 @@ namespace TVHeadEnd
 
         public async Task UpdateSeriesTimerAsync(SeriesTimerInfo info, CancellationToken cancellationToken)
         {
-            await CancelSeriesTimerAsync(info.Id, cancellationToken);
-            _lastRecordingChange = DateTime.UtcNow;
-            // TODO add if method is implemented
-            // await CreateSeriesTimerAsync(info, cancellationToken);
+            await SaveSeriesTimerAsync(info, "updateAutorecEntry", cancellationToken);
         }
 
         public async Task UpdateTimerAsync(TimerInfo info, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Fix recording scheduling and management when using the TVHeadend plugin with Jellyfin.

## Changes

* Implement TVHeadend autorecord creation and updating for Jellyfin series timers.
* Implement `ISupportsNewTimerIds` and return the IDs assigned by TVHeadend.
* Include the HTSP `eventId` when creating one-off recordings so they remain associated with their guide programs after refresh.
* Read and write TVHeadend's `serieslinkUri` for series association.
* Map channel, time-window, duplicate-detection, recording-count, padding, priority, and enabled settings for autorecord rules.
* Interpret TVHeadend autorecord windows as local minutes after midnight.
* Log malformed HTSP autorecord fields instead of silently ignoring them.
* Correct reversed default pre- and post-recording padding assignments.

## Testing

Tested with:

* Jellyfin 10.11.11
* TVHeadend plugin 13.0.0
* TVHeadend 4.3-2763~g45cbe4adb

Verified:

* Release build completes successfully.
* One-off recordings remain marked after refreshing the Jellyfin guide.
* One-off recordings can be cancelled from the Jellyfin guide and are removed from TVHeadend.
* Series recording creates a TVHeadend autorecord and matching upcoming recordings.
* Series state remains correct after refreshing the Jellyfin guide.
* Cancelling a series from Jellyfin removes its TVHeadend autorecord and upcoming recordings.
* No plugin warnings or exceptions were logged during testing.

## Note

Jellyfin Web does not immediately update guide decorations after receiving `SeriesTimerCreated`; refreshing the guide displays them correctly. This appears to be a separate Jellyfin Web event-handling issue rather than a TVHeadend plugin issue.

Fixes #35
