### PR TITLE
Do not drop channels without a channel number

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -22,6 +22,7 @@ namespace TVHeadEnd.Configuration
         public bool HideRecordingsChannel { get; set; }
         public bool EnableSubsMaudios { get; set; }
         public bool ForceDeinterlace { get; set; }
+        public bool IncludeUnnumberedChannels { get; set; }
 
         public PluginConfiguration()
         {
@@ -39,6 +40,7 @@ namespace TVHeadEnd.Configuration
             HideRecordingsChannel = false;
             EnableSubsMaudios = false;
             ForceDeinterlace = false;
+            IncludeUnnumberedChannels = true;
         }
     }
 }

--- a/TVHeadEnd/DataHelper/ChannelDataHelper.cs
+++ b/TVHeadEnd/DataHelper/ChannelDataHelper.cs
@@ -17,6 +17,7 @@ namespace TVHeadEnd.DataHelper
         private readonly Dictionary<int, HTSMessage> _data;
         private readonly Dictionary<string, string> _piconData;
         private string _channelType4Other = "Ignore";
+        private bool _includeUnnumberedChannels = true;
 
         public ChannelDataHelper(ILogger<ChannelDataHelper> logger, TunerDataHelper tunerDataHelper)
         {
@@ -32,6 +33,11 @@ namespace TVHeadEnd.DataHelper
         public void SetChannelType4Other(string channelType4Other)
         {
             _channelType4Other = channelType4Other;
+        }
+
+        public void SetIncludeUnnumberedChannels(bool includeUnnumberedChannels)
+        {
+            _includeUnnumberedChannels = includeUnnumberedChannels;
         }
 
         public void Clean()
@@ -80,9 +86,15 @@ namespace TVHeadEnd.DataHelper
                     }
                     else
                     {
-                        if (message.containsField("channelNumber") && message.getInt("channelNumber") > 0) // use only channels with number > 0
+                        bool hasNumber = message.containsField("channelNumber") && message.getInt("channelNumber") > 0;
+                        if (hasNumber || _includeUnnumberedChannels)
                         {
                             _data.Add(channelID, message);
+                        }
+                        else
+                        {
+                            _logger.LogDebug("[TVHclient] ChannelDataHelper: ignoring channel '{name}' (channelId {id}) because it has no channel number",
+                                message.containsField("channelName") ? message.getString("channelName") : "", channelID);
                         }
                     }
                 }
@@ -155,7 +167,9 @@ namespace TVHeadEnd.DataHelper
                                 ci.Name = m.getString("channelName");
                             }
 
-                            if (m.containsField("channelNumber"))
+                            // TVHeadend reports 0 for channels without a number; leave Number
+                            // empty in that case so Jellyfin sorts them by name.
+                            if (m.containsField("channelNumber") && m.getInt("channelNumber") > 0)
                             {
                                 int channelNumber = m.getInt("channelNumber");
                                 ci.Number = "" + channelNumber;

--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -154,6 +154,7 @@ namespace TVHeadEnd
             _forceDeinterlace = config.ForceDeinterlace;
 
             _channelDataHelper.SetChannelType4Other(_channelType);
+            _channelDataHelper.SetIncludeUnnumberedChannels(config.IncludeUnnumberedChannels);
 
             if (_priority < 0 || _priority > 4)
             {

--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -70,8 +70,6 @@ namespace TVHeadEnd
             _channelDataHelper = new ChannelDataHelper(loggerFactory.CreateLogger<ChannelDataHelper>());
             _dvrDataHelper = new DvrDataHelper(loggerFactory.CreateLogger<DvrDataHelper>());
             _autorecDataHelper = new AutorecDataHelper(loggerFactory.CreateLogger<AutorecDataHelper>());
-
-            _channelDataHelper.SetChannelType4Other(_channelType);
         }
 
         public static HTSConnectionHandler GetInstance(ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory)
@@ -154,6 +152,8 @@ namespace TVHeadEnd
             _channelType = config.ChannelType.Trim();
             _enableSubsMaudios = config.EnableSubsMaudios;
             _forceDeinterlace = config.ForceDeinterlace;
+
+            _channelDataHelper.SetChannelType4Other(_channelType);
 
             if (_priority < 0 || _priority > 4)
             {

--- a/TVHeadEnd/Web/tvheadend.html
+++ b/TVHeadEnd/Web/tvheadend.html
@@ -42,6 +42,13 @@
                         <option>Ignore</option>
                     </select>
                 </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="chkIncludeUnnumberedChannels" />
+                        <span>Include channels without a channel number</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">TVHeadend reports 0 for channels that have no number assigned. When unchecked, such channels are ignored. Changing this requires a server restart.</div>
+                </div>
                 <div class="checkboxContainer">
                     <label>
                         <input is="emby-checkbox" type="checkbox" id="chkHideRecordingsChannel" />

--- a/TVHeadEnd/Web/tvheadend.js
+++ b/TVHeadEnd/Web/tvheadend.js
@@ -18,6 +18,7 @@ export default function (view, params) {
             page.querySelector('#txtPrePadding').value = config.Pre_Padding || '0';
             page.querySelector('#txtPostPadding').value = config.Post_Padding || '0';
             page.querySelector('#selChannelType').value = config.ChannelType || 'Ignore';
+            page.querySelector('#chkIncludeUnnumberedChannels').checked = config.IncludeUnnumberedChannels !== false;
             page.querySelector('#chkHideRecordingsChannel').checked = config.HideRecordingsChannel || false;
             page.querySelector('#chkEnableSubsMaudios').checked = config.EnableSubsMaudios || false;
             page.querySelector('#chkForceDeinterlace').checked = config.ForceDeinterlace || false;
@@ -40,6 +41,7 @@ export default function (view, params) {
             config.Pre_Padding = form.querySelector('#txtPrePadding').value;
             config.Post_Padding = form.querySelector('#txtPostPadding').value;
             config.ChannelType = form.querySelector('#selChannelType').value;
+            config.IncludeUnnumberedChannels = form.querySelector('#chkIncludeUnnumberedChannels').checked;
             config.HideRecordingsChannel = form.querySelector('#chkHideRecordingsChannel').checked;
             config.EnableSubsMaudios = form.querySelector('#chkEnableSubsMaudios').checked;
             config.ForceDeinterlace = form.querySelector('#chkForceDeinterlace').checked;


### PR DESCRIPTION
## Problem

TVHeadend reports `channelNumber = 0` for channels that have no number assigned. This is common: DVB networks without logical channel numbers, or channels mapped from services without automatic numbering. `ChannelDataHelper.Add` discards every such channel ("use only channels with number > 0"), so a server whose channels are not numbered produces an empty channel list and no guide data in Jellyfin, with nothing in the log to explain it. The same server shows all channels in the TVHeadend UI and in Kodi.

I hit this with a fresh TVHeadend 4.3 install (71 channels, all unnumbered): HTSP connected fine, the guide refresh completed in a few seconds, and the Live TV section stayed empty. This was reported before in #13.

## Change

`Do not drop channels without a channel number`
- Keep channels with `channelNumber` 0 and leave `ChannelInfo.Number` empty for them, so Jellyfin sorts them by name instead of showing "0" for all of them.
- New configuration option **Include channels without a channel number** (checkbox on the plugin page, `IncludeUnnumberedChannels`, default enabled). Unchecking it restores the previous behaviour for setups that use an unset channel number to hide channels. Changing it requires a server restart, like the other channel settings.
- Skipped channels are now logged at debug level.

`Apply the channel type for 'Other' services after reading the configuration`
- `SetChannelType4Other` was only called from the constructor, before `init()` had read the configuration, so it always received `null`. The "channel type for Other" setting therefore never worked: services tagged `Other` threw a `NullReferenceException` in `BuildChannelInfos` and were dropped. It is now applied in `init()` together with the new option.

## Notes

- Default: I chose to include unnumbered channels by default because silently dropping the whole lineup is the worse failure mode. Happy to flip the default to keep the exact old behaviour if you prefer.
- No version bump, as requested on earlier PRs.
- Tested on Jellyfin 10.11.11 with TVHeadend 4.3-2763: 71 channels (TV and radio types detected correctly) and the full EPG show up after a guide refresh. With the option unchecked the add condition is the original one, so the previous behaviour is unchanged.

## Related issues

- #13 - same root cause. The reporter found this exact condition in 2019 ("in a fresh setup we won't ever see channels") and the issue was closed with the workaround of assigning channel numbers in TVHeadend; the workaround was never documented and the condition was never changed.
