### PR TITLE
Do not offer data streams to Jellyfin

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -523,9 +523,13 @@ namespace TVHeadEnd
                 mediaSourceInfo.Container = info.Container;
                 _logger.LogDebug("        Container:                  {Container}", info.Container);
 
-                mediaSourceInfo.MediaStreams = info.MediaStreams;
+                // Data streams are left out. FFmpeg surfaces the DVB EPG table, PID 0x12, as
+                // a stream called "epg", and no container Jellyfin produces can carry it. If
+                // Jellyfin selects it as an output stream the muxer gives up with "Could not
+                // find tag for codec epg in stream #0" and playback never starts.
+                mediaSourceInfo.MediaStreams = [.. info.MediaStreams.Where(i => i.Type != MediaStreamType.Data)];
                 _logger.LogDebug("        MediaStreams:               ");
-                LogMediaStreamList(info.MediaStreams, "                       ");
+                LogMediaStreamList(mediaSourceInfo.MediaStreams, "                       ");
 
                 mediaSourceInfo.RunTimeTicks = info.RunTimeTicks;
                 _logger.LogDebug("        RunTimeTicks:               {RunTimeTicks}", info.RunTimeTicks);


### PR DESCRIPTION
Part of a small series that cuts the delay between clicking a channel and seeing a picture when Jellyfin takes its Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### What this one does

The probe run in `ProbeStream` returns every stream ffmpeg finds in the transport stream, including the DVB EPG table on PID `0x12`, which ffmpeg surfaces as a data stream with the codec name `epg`. That list is handed to Jellyfin as `MediaSourceInfo.MediaStreams`, so Jellyfin can and sometimes does select it as an output stream. No container Jellyfin produces is able to carry it, and the muxer then gives up:

```
[mp4] Could not find tag for codec epg in stream #0, codec not currently supported in container
[out#0/hls] Could not write header (incorrect codec parameters ?): Invalid argument
```

Playback never starts. This drops streams of type `Data` from the list, so a stream nothing downstream can use is never offered in the first place.

### What this does not do

It does not, on its own, fix the failure above. Jellyfin maps output streams by absolute index (`-map 0:0 -map 0:1`), and ffmpeg's own enumeration of a live transport stream is not stable between one open and the next: the EPG stream shows up at index 0 on some opens and at the end on others. When the two disagree, the wrong streams are selected whatever the plugin declared. That mismatch belongs to Jellyfin's stream selection rather than to this plugin, and is reported separately as jellyfin/jellyfin#17954.

So this is a correctness cleanup with no measured latency gain. It removes one of the ways the mismatch can turn into a hard failure, not the mismatch itself.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker, TVHeadend 4.3, two DVB-T tuners, VAAPI transcoding on an Intel Celeron J4105, with `EnableSubsMaudios` turned on. Treat it as one data point rather than a benchmark.

### Reported as

Related to #108, where the real video and audio sit at `0:2` and `0:3` while Jellyfin starts ffmpeg with `-map 0:0`, mapping a data or private stream instead. That report is about recordings rather than live channels, and the underlying index mismatch is Jellyfin's rather than this plugin's — filed as jellyfin/jellyfin#17954 — but not offering a stream nothing can carry removes one way it turns into a hard failure.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin  ← you are here

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.






