### PR TITLE
Make the stream analysis limit configurable

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -27,6 +27,7 @@ namespace TVHeadEnd.Configuration
             HideRecordingsChannel = false;
             EnableSubsMaudios = false;
             ForceDeinterlace = false;
+            AnalyzeDurationMs = 2000;
         }
 
         public string TVH_ServerName { get; set; }
@@ -54,5 +55,7 @@ namespace TVHeadEnd.Configuration
         public bool EnableSubsMaudios { get; set; }
 
         public bool ForceDeinterlace { get; set; }
+
+        public int AnalyzeDurationMs { get; set; }
     }
 }

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -428,7 +428,7 @@ namespace TVHeadEnd
                 livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
-                livetvasset.AnalyzeDurationMs = 2000;
+                livetvasset.AnalyzeDurationMs = Plugin.Instance.Configuration.AnalyzeDurationMs;
                 livetvasset.SupportsDirectStream = false;
                 livetvasset.RequiresClosing = true;
                 livetvasset.SupportsProbing = false;
@@ -466,7 +466,7 @@ namespace TVHeadEnd
                     Id = channelId,
                     Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
                     Protocol = MediaProtocol.Http,
-                    AnalyzeDurationMs = 2000,
+                    AnalyzeDurationMs = Plugin.Instance.Configuration.AnalyzeDurationMs,
                     SupportsDirectStream = false,
                     SupportsProbing = false,
                     Container = "mpegts",

--- a/TVHeadEnd/Web/tvheadend.html
+++ b/TVHeadEnd/Web/tvheadend.html
@@ -60,6 +60,10 @@
                     </label>
                     <div class="fieldDescription checkboxFieldDescription">Note: Changing this requires a server restart.</div>
                 </div>
+                <div class="inputContainer">
+                    <input is="emby-input" type="number" id="txtAnalyzeDurationMs" min="100" max="10000" label="Stream analysis limit (ms)" />
+                    <div class="fieldDescription">How long ffmpeg may spend working out what a channel contains before playback starts. It uses all of it, because DVB subtitle streams send nothing while the analysis runs, so lowering this shortens every channel change. Streams start being missed below roughly 200 ms.</div>
+                </div>
                 <div>
                     <button is="emby-button" type="submit" class="raised button-submit block">
                         <span>Save</span>

--- a/TVHeadEnd/Web/tvheadend.js
+++ b/TVHeadEnd/Web/tvheadend.js
@@ -20,6 +20,7 @@ export default function (view, params) {
             page.querySelector('#chkHideRecordingsChannel').checked = config.HideRecordingsChannel || false;
             page.querySelector('#chkEnableSubsMaudios').checked = config.EnableSubsMaudios || false;
             page.querySelector('#chkForceDeinterlace').checked = config.ForceDeinterlace || false;
+            page.querySelector('#txtAnalyzeDurationMs').value = config.AnalyzeDurationMs || '2000';
             Dashboard.hideLoadingMsg();
         });
     });
@@ -41,6 +42,7 @@ export default function (view, params) {
             config.HideRecordingsChannel = form.querySelector('#chkHideRecordingsChannel').checked;
             config.EnableSubsMaudios = form.querySelector('#chkEnableSubsMaudios').checked;
             config.ForceDeinterlace = form.querySelector('#chkForceDeinterlace').checked;
+            config.AnalyzeDurationMs = form.querySelector('#txtAnalyzeDurationMs').value;
             ApiClient.updatePluginConfiguration(TVHclientConfigurationPageVar.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
         });
         return false;


### PR DESCRIPTION
Part of a small series that cuts the delay between clicking a channel and seeing a picture when Jellyfin takes its Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### What this one does

`GetChannelStream` hardcodes `AnalyzeDurationMs = 2000`, so ffmpeg is allowed two seconds to work out what the stream contains before it produces anything. That limit is normally an upper bound that ffmpeg leaves early, but with DVB it does not: the DVB subtitle streams send no packets while the analysis runs, so their parameters are never determined and ffmpeg waits the budget out every single time. Two seconds are spent on every channel change, whether or not they are needed.

This makes the value configurable from the plugin page, and leaves the default at 2000 so nothing changes for existing installations.

### Measured

`ffprobe` against the same DVB-T channel, same command line as the one Jellyfin builds, wall clock from launch to exit:

| analyzeduration | total |
|---|---|
| 2 000 000 µs (current default) | 2858 ms |
| 1 000 000 µs | 1698 ms |
| 500 000 µs | 1292 ms |
| 200 000 µs | 963 ms |
| 0 | 5761 ms |

The video stream was correctly detected at every setting including 200 ms. The floor of roughly 900 ms is connection setup plus reading the PAT and PMT.

Worth noting for anyone tempted by it: `0` does not mean "do not analyse", it means "no limit", and it is by far the worst setting. The input box is bounded at 100 ms.

The trade-off is real and is why this is a setting rather than a lower default: the less ffmpeg analyses, the more likely it is to miss a stream that is slow to appear.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker, TVHeadend 4.3, two DVB-T tuners, VAAPI transcoding on an Intel Celeron J4105. Treat the figures as one data point rather than a benchmark.

### Reported as

Part of #61 (five to eight seconds before a channel appears) and of #119, whose author observes that probing a live stream costs several seconds at startup. Two of those seconds are the analysis budget set by this plugin.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit  ← you are here
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.






