### PR TITLE
Probe a channel once per channel change instead of twice

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -40,6 +41,15 @@ namespace TVHeadEnd
         private readonly AccessTicketHandler _channelTicketHandler;
 
         private readonly ILogger<LiveTvService> _logger;
+
+        /// <summary>
+        /// How long a probe result stays usable. Jellyfin asks for the media sources and
+        /// then opens the stream a few seconds later; without this both calls probe the
+        /// same channel, and each probe costs a TVHeadend subscription.
+        /// </summary>
+        private readonly TimeSpan _probeCacheDuration = TimeSpan.FromSeconds(30);
+
+        private readonly ConcurrentDictionary<string, (DateTime ProbedAt, MediaInfo Info)> _probeCache = new();
 
         public LiveTvService(ILoggerFactory loggerFactory, IMediaEncoder mediaEncoder, HTSConnectionHandler connectionHandler)
         {
@@ -439,7 +449,7 @@ namespace TVHeadEnd
                 // Probe the asset stream to determine available sub-streams
                 string livetvasset_probeUrl = string.Empty + livetvasset.Path;
                 string livetvasset_source = "LiveTV";
-                await ProbeStream(livetvasset, livetvasset_probeUrl, livetvasset_source, cancellationToken).ConfigureAwait(false);
+                await ProbeStream(livetvasset, livetvasset_probeUrl, livetvasset_source, channelId, cancellationToken).ConfigureAwait(false);
 
                 // If enabled, force video deinterlacing for channels
                 if (_htsConnectionHandler.GetForceDeinterlace())
@@ -492,8 +502,20 @@ namespace TVHeadEnd
             }
         }
 
-        private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
+        private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, string cacheKey, CancellationToken cancellationToken)
         {
+            var originalRuntime = mediaSourceInfo.RunTimeTicks;
+
+            if (_probeCache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.ProbedAt < _probeCacheDuration)
+            {
+                _logger.LogInformation(
+                    "Reusing the {Source} probe taken {Age} seconds ago, no extra subscription needed",
+                    source,
+                    (int)(DateTime.UtcNow - cached.ProbedAt).TotalSeconds);
+                ApplyMediaInfo(mediaSourceInfo, cached.Info, originalRuntime);
+                return;
+            }
+
             _logger.LogInformation("Probe stream for {Source}", source);
             _logger.LogInformation("Probe URL: {ProbeUrl}", probeUrl);
 
@@ -504,7 +526,6 @@ namespace TVHeadEnd
                 ExtractChapters = false,
             };
 
-            var originalRuntime = mediaSourceInfo.RunTimeTicks;
             Stopwatch stopWatch = new Stopwatch();
             stopWatch.Start();
             MediaInfo info = await _mediaEncoder.GetMediaInfo(req, cancellationToken).ConfigureAwait(false);
@@ -515,72 +536,80 @@ namespace TVHeadEnd
 
             if (info != null)
             {
-                _logger.LogDebug("Probe returned:");
-
-                mediaSourceInfo.Bitrate = info.Bitrate;
-                _logger.LogDebug("        BitRate:                    {BitRate}", info.Bitrate);
-
-                mediaSourceInfo.Container = info.Container;
-                _logger.LogDebug("        Container:                  {Container}", info.Container);
-
-                mediaSourceInfo.MediaStreams = info.MediaStreams;
-                _logger.LogDebug("        MediaStreams:               ");
-                LogMediaStreamList(info.MediaStreams, "                       ");
-
-                mediaSourceInfo.RunTimeTicks = info.RunTimeTicks;
-                _logger.LogDebug("        RunTimeTicks:               {RunTimeTicks}", info.RunTimeTicks);
-
-                mediaSourceInfo.Size = info.Size;
-                _logger.LogDebug("        Size:                       {Size}", info.Size);
-
-                mediaSourceInfo.Timestamp = info.Timestamp;
-                _logger.LogDebug("        Timestamp:                  {Timestamp}", info.Timestamp);
-
-                mediaSourceInfo.Video3DFormat = info.Video3DFormat;
-                _logger.LogDebug("        Video3DFormat:              {Video3DFormat}", info.Video3DFormat);
-
-                mediaSourceInfo.VideoType = info.VideoType;
-                _logger.LogDebug("        VideoType:                  {VideoType}", info.VideoType);
-
-                mediaSourceInfo.RequiresClosing = true;
-                _logger.LogDebug("        RequiresClosing:            {RequiresClosing}", info.RequiresClosing);
-
-                mediaSourceInfo.RequiresOpening = true;
-                _logger.LogDebug("        RequiresOpening:            {RequiresOpening}", info.RequiresOpening);
-
-                mediaSourceInfo.SupportsDirectPlay = true;
-                _logger.LogDebug("        SupportsDirectPlay:         {SupportsDirectPlay}", info.SupportsDirectPlay);
-
-                mediaSourceInfo.SupportsDirectStream = true;
-                _logger.LogDebug("        SupportsDirectStream:       {SupportsDirectStream}", info.SupportsDirectStream);
-
-                mediaSourceInfo.SupportsTranscoding = true;
-                _logger.LogDebug("        SupportsTranscoding:        {SupportsTranscoding}", info.SupportsTranscoding);
-
-                mediaSourceInfo.DefaultSubtitleStreamIndex = null;
-                _logger.LogDebug("        DefaultSubtitleStreamIndex: n/a");
-
-                if (!originalRuntime.HasValue)
-                {
-                    mediaSourceInfo.RunTimeTicks = null;
-                    _logger.LogDebug("        Original runtime:           n/a");
-                }
-
-                var audioStream = mediaSourceInfo.MediaStreams.FirstOrDefault(i => i.Type == MediaStreamType.Audio);
-                if (audioStream == null || audioStream.Index == -1)
-                {
-                    mediaSourceInfo.DefaultAudioStreamIndex = null;
-                    _logger.LogDebug("        DefaultAudioStreamIndex:    n/a");
-                }
-                else
-                {
-                    mediaSourceInfo.DefaultAudioStreamIndex = audioStream.Index;
-                    _logger.LogDebug("        DefaultAudioStreamIndex:    '{DefaultAudioStreamIndex}'", info.DefaultAudioStreamIndex);
-                }
+                _probeCache[cacheKey] = (DateTime.UtcNow, info);
+                ApplyMediaInfo(mediaSourceInfo, info, originalRuntime);
             }
             else
             {
                 _logger.LogError("Cannot probe {Source} stream", source);
+            }
+        }
+
+        private void ApplyMediaInfo(MediaSourceInfo mediaSourceInfo, MediaInfo info, long? originalRuntime)
+        {
+            _logger.LogDebug("Probe returned:");
+
+            mediaSourceInfo.Bitrate = info.Bitrate;
+            _logger.LogDebug("        BitRate:                    {BitRate}", info.Bitrate);
+
+            mediaSourceInfo.Container = info.Container;
+            _logger.LogDebug("        Container:                  {Container}", info.Container);
+
+            // Copy the list: one probe result is applied to more than one media source, and
+            // the deinterlace override in GetChannelStream mutates the streams it is given.
+            mediaSourceInfo.MediaStreams = [.. info.MediaStreams];
+            _logger.LogDebug("        MediaStreams:               ");
+            LogMediaStreamList(info.MediaStreams, "                       ");
+
+            mediaSourceInfo.RunTimeTicks = info.RunTimeTicks;
+            _logger.LogDebug("        RunTimeTicks:               {RunTimeTicks}", info.RunTimeTicks);
+
+            mediaSourceInfo.Size = info.Size;
+            _logger.LogDebug("        Size:                       {Size}", info.Size);
+
+            mediaSourceInfo.Timestamp = info.Timestamp;
+            _logger.LogDebug("        Timestamp:                  {Timestamp}", info.Timestamp);
+
+            mediaSourceInfo.Video3DFormat = info.Video3DFormat;
+            _logger.LogDebug("        Video3DFormat:              {Video3DFormat}", info.Video3DFormat);
+
+            mediaSourceInfo.VideoType = info.VideoType;
+            _logger.LogDebug("        VideoType:                  {VideoType}", info.VideoType);
+
+            mediaSourceInfo.RequiresClosing = true;
+            _logger.LogDebug("        RequiresClosing:            {RequiresClosing}", true);
+
+            mediaSourceInfo.RequiresOpening = true;
+            _logger.LogDebug("        RequiresOpening:            {RequiresOpening}", true);
+
+            mediaSourceInfo.SupportsDirectPlay = true;
+            _logger.LogDebug("        SupportsDirectPlay:         {SupportsDirectPlay}", true);
+
+            mediaSourceInfo.SupportsDirectStream = true;
+            _logger.LogDebug("        SupportsDirectStream:       {SupportsDirectStream}", true);
+
+            mediaSourceInfo.SupportsTranscoding = true;
+            _logger.LogDebug("        SupportsTranscoding:        {SupportsTranscoding}", true);
+
+            mediaSourceInfo.DefaultSubtitleStreamIndex = null;
+            _logger.LogDebug("        DefaultSubtitleStreamIndex: n/a");
+
+            if (!originalRuntime.HasValue)
+            {
+                mediaSourceInfo.RunTimeTicks = null;
+                _logger.LogDebug("        Original runtime:           n/a");
+            }
+
+            var audioStream = mediaSourceInfo.MediaStreams.FirstOrDefault(i => i.Type == MediaStreamType.Audio);
+            if (audioStream == null || audioStream.Index == -1)
+            {
+                mediaSourceInfo.DefaultAudioStreamIndex = null;
+                _logger.LogDebug("        DefaultAudioStreamIndex:    n/a");
+            }
+            else
+            {
+                mediaSourceInfo.DefaultAudioStreamIndex = audioStream.Index;
+                _logger.LogDebug("        DefaultAudioStreamIndex:    '{DefaultAudioStreamIndex}'", audioStream.Index);
             }
         }
 


### PR DESCRIPTION
Part of a small series that cuts the delay between clicking a channel and seeing a picture when Jellyfin takes its Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### What this one does

Jellyfin calls `GetChannelStreamMediaSources` to decide what to do with a channel, then `GetChannelStream` a few seconds later to actually open it. Both go through `ProbeStream`, so a single channel change probes the same channel twice, and each probe opens its own TVHeadend subscription. A tuner is therefore tuned three times to watch one channel: twice to look at it, once to stream it.

Probe results are now kept for 30 seconds and reused. That is long enough to cover the pair of calls Jellyfin makes for one channel change, and short enough that nothing is remembered between them.

Visible in the log as:

```
Probe stream for "LiveTV"
Reusing the "LiveTV" probe taken 3 seconds ago, no extra subscription needed
```

### Measured

From the plugin's first call to playback starting:

| | before | after |
|---|---|---|
| channel change | 12.0 s | 6.4 s |
| TVHeadend subscriptions per change | 3 | 2 |

### Implementation notes

The assignments that were inline in `ProbeStream` move into `ApplyMediaInfo`, so a reused result and a fresh one are applied through exactly the same code. The stream list is copied rather than shared, because one probe result is now applied to more than one `MediaSourceInfo` while the `ForceDeinterlace` override mutates the streams in place.

Deliberately kept in memory only, and deliberately short. A longer lived cache is tempting and turned out to be a bad idea: ffmpeg's enumeration of a live transport stream is not stable between opens, and remembering stream indices for minutes makes Jellyfin's index based mapping wrong more often, not less.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker, TVHeadend 4.3, two DVB-T tuners, VAAPI transcoding on an Intel Celeron J4105. Treat the figures as one data point rather than a benchmark.

### Reported as

Addresses #61, where a channel takes five to eight seconds to appear, and part of #119, whose author notes that "probing a live stream adds a few seconds to startup" and asks whether the plugin could avoid paying that cost. This halves it by paying it once per channel change instead of twice.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two  ← you are here
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.






