### PR TITLE
Stop putting TVHeadend credentials in stream URLs

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -228,12 +228,10 @@ namespace TVHeadEnd
         /// <returns>The HTTP base URL.</returns>
         private string BuildHttpBaseUrl()
         {
-            if (_enableSubsMaudios)
-            {
-                // Use HTTP basic auth instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                return "http://" + _userName + ":" + _password + "@" + _tvhServerName + ":" + _httpPort + _webRoot;
-            }
-
+            // Credentials must never be part of the URL. Jellyfin logs the media source path
+            // and the full ffmpeg command line, so a password placed here is written to the
+            // server log in plain text. TVHeadend's tickets are used for authentication
+            // instead, and a fresh one is requested every time a stream is opened.
             return "http://" + _tvhServerName + ":" + _httpPort + _webRoot;
         }
 

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -424,8 +424,9 @@ namespace TVHeadEnd
 
                 livetvasset.Id = channelId;
 
-                // Use HTTP basic auth in HTTP header instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
+                // A fresh ticket is requested every time this method runs, which includes the
+                // calls Jellyfin makes when the viewer switches audio or subtitle track.
+                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
                 livetvasset.AnalyzeDurationMs = 2000;
@@ -492,10 +493,26 @@ namespace TVHeadEnd
             }
         }
 
+        private string RedactCredentials(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return url;
+            }
+
+            var builder = new UriBuilder(uri)
+            {
+                UserName = string.Empty,
+                Password = string.Empty
+            };
+
+            return builder.Uri.ToString();
+        }
+
         private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Probe stream for {Source}", source);
-            _logger.LogInformation("Probe URL: {ProbeUrl}", probeUrl);
+            _logger.LogInformation("Probe URL: {ProbeUrl}", RedactCredentials(probeUrl));
 
             MediaInfoRequest req = new MediaInfoRequest
             {


### PR DESCRIPTION
Part of a small series that cuts the delay between clicking a channel and seeing a picture when Jellyfin takes its Live TV from TVHeadend. This one is not about latency, it is a credential leak found along the way.

### The problem

When *subtitles and multiple audio tracks* is enabled, `BuildHttpBaseUrl` puts HTTP basic auth credentials into the stream URL:

```csharp
return "http://" + _userName + ":" + _password + "@" + _tvhServerName + ":" + _httpPort + _webRoot;
```

Jellyfin then writes that URL to its log in three separate places: the plugin's own `Probe URL` line, `MediaSourceManager`'s `Live stream opened` dump, and the full ffmpeg command line. On the test system the TVHeadend password appeared four times per playback, in the file users are most likely to paste into a forum thread or an issue report when asking for help.

### What this one does

The other branch of `GetChannelStream` already authenticates with a TVHeadend ticket and leaks nothing. This makes both branches do the same: `ticket.Url` instead of `ticket.Path`, and no credentials in the base URL. Occurrences of the password in the log go from four per playback to zero.

The comment being removed claimed basic auth was needed so viewers could switch audio or subtitle track at any time. That turns out not to hold. `GetChannelStream` runs again on every track switch and requests a fresh ticket, and TVHeadend accepts a ticket repeatedly inside its validity window — visible in its own log, the same ticket served twice three seconds apart:

```
using ticket f301276c... for /stream/channelid/894738492
using ticket f301276c... for /stream/channelid/894738492
```

Switching audio track was checked and still works.

`RedactCredentials` is kept as a safety net on the probe URL log, so that a URL carrying credentials for any other reason is never written out.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker, TVHeadend 4.3, two DVB-T tuners, with `EnableSubsMaudios` turned on, checking both playback and audio track switching.

### Reported as

Fixes #102, which quotes the very line this removes:

```
[INF] TVHeadEnd.LiveTvService: Probe URL: http://jellyfin:WHOADUDEWTF@1.2.3.4:9981/stream/channelid/86753
```

### The series

- #127 — credentials taken out of stream URLs  ← you are here
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.






