### PR TITLE
Let the streaming profile be chosen, and say what it produces

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -21,6 +21,8 @@ namespace TVHeadEnd.Configuration
             Password = string.Empty;
             Priority = 5;
             Profile = string.Empty;
+            StreamingProfile = string.Empty;
+            Container = "mpegts";
             Pre_Padding = 0;
             Post_Padding = 0;
             ChannelType = "Ignore";
@@ -42,6 +44,10 @@ namespace TVHeadEnd.Configuration
         public int Priority { get; set; }
 
         public string Profile { get; set; }
+
+        public string StreamingProfile { get; set; }
+
+        public string Container { get; set; }
 
         public int Pre_Padding { get; set; }
 

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -425,14 +425,14 @@ namespace TVHeadEnd
                 livetvasset.Id = channelId;
 
                 // Use HTTP basic auth in HTTP header instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
+                livetvasset.Path = WithStreamingProfile(_htsConnectionHandler.GetHttpBaseUrl() + ticket.Path);
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
                 livetvasset.AnalyzeDurationMs = 2000;
                 livetvasset.SupportsDirectStream = false;
                 livetvasset.RequiresClosing = true;
                 livetvasset.SupportsProbing = false;
-                livetvasset.Container = "mpegts";
+                livetvasset.Container = ConfiguredContainer();
                 livetvasset.RequiresOpening = true;
                 livetvasset.IsInfiniteStream = true;
 
@@ -464,12 +464,12 @@ namespace TVHeadEnd
                 return new MediaSourceInfo
                 {
                     Id = channelId,
-                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
+                    Path = WithStreamingProfile(_htsConnectionHandler.GetHttpBaseUrl() + ticket.Url),
                     Protocol = MediaProtocol.Http,
                     AnalyzeDurationMs = 2000,
                     SupportsDirectStream = false,
                     SupportsProbing = false,
-                    Container = "mpegts",
+                    Container = ConfiguredContainer(),
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream
@@ -490,6 +490,30 @@ namespace TVHeadEnd
                     }
                 };
             }
+        }
+
+        private static string WithStreamingProfile(string url)
+        {
+            var profile = Plugin.Instance.Configuration.StreamingProfile;
+
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return url;
+            }
+
+            var separator = url.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+
+            return url + separator + "profile=" + Uri.EscapeDataString(profile.Trim());
+        }
+
+        private static string ConfiguredContainer()
+        {
+            // Which container a streaming profile produces cannot be asked of TVHeadend:
+            // api/profile/list returns names only, and the class is admin only. It therefore
+            // has to be stated next to the profile it belongs to.
+            var container = Plugin.Instance.Configuration.Container;
+
+            return string.IsNullOrWhiteSpace(container) ? "mpegts" : container.Trim();
         }
 
         private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
@@ -580,7 +604,10 @@ namespace TVHeadEnd
             }
             else
             {
-                _logger.LogError("Cannot probe {Source} stream", source);
+                _logger.LogError(
+                    "Cannot probe {Source} stream. It is announced as {Container}; if the streaming profile in use produces something else, ffmpeg is given the wrong demuxer and the probe cannot succeed",
+                    source,
+                    mediaSourceInfo.Container);
             }
         }
 

--- a/TVHeadEnd/Web/tvheadend.html
+++ b/TVHeadEnd/Web/tvheadend.html
@@ -26,6 +26,14 @@
                     <input is="emby-input" type="text" id="txtProfile" label="Profile for Recordings" />
                 </div>
                 <div class="inputContainer">
+                    <input is="emby-input" type="text" id="txtStreamingProfile" label="Streaming Profile" />
+                    <div class="fieldDescription">Name of the TVHeadend streaming profile to request when watching. Leave empty to use whichever profile TVHeadend has marked as default, which is what this plugin has always done.</div>
+                </div>
+                <div class="inputContainer">
+                    <input is="emby-input" type="text" id="txtContainer" label="Container that profile produces" />
+                    <div class="fieldDescription">Jellyfin is told the stream is in this container and hands it to ffmpeg, so it has to match the profile above. Leave it at mpegts for a pass-through profile; set matroska or mp4 if the profile rebuilds the stream.</div>
+                </div>
+                <div class="inputContainer">
                     <input is="emby-input" type="text" id="txtPrePadding" label="Pre-recording Padding in seconds" />
                     <div class="fieldDescription">TVHeadend stores padding in whole minutes, so values are rounded down and anything below 60 seconds has no effect.</div>
                 </div>

--- a/TVHeadEnd/Web/tvheadend.js
+++ b/TVHeadEnd/Web/tvheadend.js
@@ -14,6 +14,8 @@ export default function (view, params) {
             page.querySelector('#txtPassword').value = config.Password || '';
             page.querySelector('#txtPriority').value = config.Priority || '5';
             page.querySelector('#txtProfile').value = config.Profile || '';
+            page.querySelector('#txtStreamingProfile').value = config.StreamingProfile || '';
+            page.querySelector('#txtContainer').value = config.Container || 'mpegts';
             page.querySelector('#txtPrePadding').value = config.Pre_Padding || '0';
             page.querySelector('#txtPostPadding').value = config.Post_Padding || '0';
             page.querySelector('#selChannelType').value = config.ChannelType || 'Ignore';
@@ -35,6 +37,8 @@ export default function (view, params) {
             config.Password = form.querySelector('#txtPassword').value;
             config.Priority = form.querySelector('#txtPriority').value;
             config.Profile = form.querySelector('#txtProfile').value;
+            config.StreamingProfile = form.querySelector('#txtStreamingProfile').value;
+            config.Container = form.querySelector('#txtContainer').value;
             config.Pre_Padding = form.querySelector('#txtPrePadding').value;
             config.Post_Padding = form.querySelector('#txtPostPadding').value;
             config.ChannelType = form.querySelector('#selChannelType').value;


### PR DESCRIPTION
Part of a small series around Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### What cannot be configured today

Which TVHeadend streaming profile is used when watching a channel. The stream URL is built as

```
/stream/channelid/N?ticket=...
```

with no profile, so TVHeadend falls back to whichever profile is marked as default — normally `pass`. The existing `Profile` setting does not control this: it is sent as `configName` on `createAutorec` and `createTimer`, which is the DVR configuration name, and its label already says *Profile for Recordings*.

### Why it matters

`pass` is a raw MPEG-TS pass-through. On a DVB tuner that is exactly right: the hardware has already filtered the PIDs, and the output is a clean single-program stream that ffmpeg probes in about four seconds.

On an IPTV network there is no hardware filter. On the setup this was found on, the pass-through handed ffmpeg a stream whose composition changed between opens — 5, then 6, then 38 streams for the same channel within a few minutes. `avformat_find_stream_info` never completes and reads until `probesize` is exhausted. Jellyfin's default is `1G`, which at broadcast bitrates is roughly half an hour, so playback simply never starts.

The probe time scales exactly with the budget, which is what "never completes" looks like from outside:

| probesize | time |
|---|---|
| 2 MB | 3 731 ms |
| 5 MB | 9 141 ms |
| 10 MB | 17 544 ms |
| 20 MB | 35 188 ms |

A profile that demuxes and remuxes avoids it entirely. Same channel, same probe budget, same source, minutes apart:

| profile | result |
|---|---|
| `pass`, the default today | 50 201 ms, killed, 0 streams |
| a libav profile | 1 931 ms, 4 streams |

### Why the container comes with it

Those profiles produce Matroska or MP4, not MPEG-TS. `Container` was hardcoded:

```csharp
livetvasset.Container = "mpegts";
```

and Jellyfin passes it to ffmpeg as `-f mpegts`, so announcing the wrong container sends the probe to the wrong demuxer and it stalls in exactly the same way — 50 199 ms and nothing, against 2 949 ms when the container is right. Choosing a profile without being able to state what it produces would therefore be useless, which is why both settings are here rather than in separate pull requests.

The container cannot be derived. `api/profile/list` returns names and uuids only:

```json
{"key":"317ff9e6...","val":"pass"}
{"key":"31937b71...","val":"matroska"}
```

the class that would say what a profile produces sits behind `ACCESS_ADMIN`, which a plugin has no business requiring, and profile names are free-form so it cannot be guessed either.

### Compatibility

Both settings default to today's behaviour: no profile requested, container announced as `mpegts`. Existing installations are unaffected.

The `Cannot probe` message now names the announced container, so a mismatch shows up in the log instead of being a silent stall.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker, TVHeadend 4.3, DVB-T tuners and an IPTV network, `EnableSubsMaudios` on. Every figure above comes from ffprobe runs on that machine against the same channel, with the serving adapter checked each time so that pass-through and demuxing were compared on the same source. Treat them as one data point rather than a benchmark.

### A caveat worth knowing before merging

Choosing a profile that rebuilds the stream also changes how subtitles reach Jellyfin, and that runs into a bug in the server.

With an MPEG-TS pass-through, DVB subtitles arrive as bitmap. Jellyfin drops them with `-sn` and they never appear in the client. With a Matroska profile, TVHeadend presents the same tracks as text (`subrip`). They then show up in the subtitle menu, and selecting one — or having subtitles set to automatic — ends playback outright:

```
ResourceNotFoundException: MediaSource 688167343 has no subtitle cache (non-GUID Id, e.g. Live TV stream).
   at MediaBrowser.MediaEncoding.Subtitles.SubtitleEncoder.GetReadableFile(...)
```

Jellyfin cannot extract subtitles from a Live TV source: the cache path needs a GUID-shaped media source id, which Live TV does not have, and the code path above it calls `ExtractAllExtractableSubtitles`, which assumes a source with an end. Reported as jellyfin/jellyfin#17992, and related to jellyfin/jellyfin#10914.

None of this is touched by the default, which requests no profile and announces `mpegts` exactly as today. It only appears for someone who deliberately configures a rebuilding profile, which is the whole point of the setting — so it seemed better stated here than discovered later. Until the server side is fixed, setting the subtitle mode to None avoids it.

### Reported as

Fixes #43, opened in September 2021:

> Is there any way to choose what profile is used for streaming, not just the DVR?

Five years on, the answer is still no, and the report is right about why: the existing setting only reaches the DVR.

Also addresses #99, where TVHeadend refuses the stream outright because no profile is named:

```
[ERROR] profile: unable to select a working profile (asked '(null)' alt 'channel')
[ERROR] http: HTTP/1.1 GET (1) /stream/channelid -- 503
```

`asked '(null)'` is this plugin: it never requests a profile, so TVHeadend has to resolve one on its own and returns 503 when it cannot.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container  ← you are here
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.







