### PR TITLE
Allow a fallback bitrate so Jellyfin stops inventing one

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -27,6 +27,7 @@ namespace TVHeadEnd.Configuration
             HideRecordingsChannel = false;
             EnableSubsMaudios = false;
             ForceDeinterlace = false;
+            FallbackBitrate = 0;
         }
 
         public string TVH_ServerName { get; set; }
@@ -54,5 +55,7 @@ namespace TVHeadEnd.Configuration
         public bool EnableSubsMaudios { get; set; }
 
         public bool ForceDeinterlace { get; set; }
+
+        public int FallbackBitrate { get; set; }
     }
 }

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -469,6 +469,7 @@ namespace TVHeadEnd
                     AnalyzeDurationMs = 2000,
                     SupportsDirectStream = false,
                     SupportsProbing = false,
+                    Bitrate = FallbackBitrate(),
                     Container = "mpegts",
                     MediaStreams = new List<MediaStream>
                     {
@@ -490,6 +491,15 @@ namespace TVHeadEnd
                     }
                 };
             }
+        }
+
+        private static int? FallbackBitrate()
+        {
+            // Left unset, Jellyfin has to guess a figure from the resolution and frame rate,
+            // and the guess is wildly high on broadcast material.
+            var kbps = Plugin.Instance.Configuration.FallbackBitrate;
+
+            return kbps > 0 ? kbps * 1000 : null;
         }
 
         private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
@@ -517,7 +527,7 @@ namespace TVHeadEnd
             {
                 _logger.LogDebug("Probe returned:");
 
-                mediaSourceInfo.Bitrate = info.Bitrate;
+                mediaSourceInfo.Bitrate = info.Bitrate > 0 ? info.Bitrate : FallbackBitrate();
                 _logger.LogDebug("        BitRate:                    {BitRate}", info.Bitrate);
 
                 mediaSourceInfo.Container = info.Container;

--- a/TVHeadEnd/Web/tvheadend.html
+++ b/TVHeadEnd/Web/tvheadend.html
@@ -60,6 +60,10 @@
                     </label>
                     <div class="fieldDescription checkboxFieldDescription">Note: Changing this requires a server restart.</div>
                 </div>
+                <div class="inputContainer">
+                    <input is="emby-input" type="number" id="txtFallbackBitrate" min="0" max="100000" label="Fallback bitrate (kb/s)" />
+                    <div class="fieldDescription">Used when the bitrate of a channel is not known. Without it Jellyfin estimates one from the resolution and frame rate, which on a 50 fps broadcast lands in the hundreds of megabits and can stop a hardware encoder from starting at all. Something around 8000 suits HD broadcast television. Leave at 0 to declare nothing, as before.</div>
+                </div>
                 <div>
                     <button is="emby-button" type="submit" class="raised button-submit block">
                         <span>Save</span>

--- a/TVHeadEnd/Web/tvheadend.js
+++ b/TVHeadEnd/Web/tvheadend.js
@@ -20,6 +20,7 @@ export default function (view, params) {
             page.querySelector('#chkHideRecordingsChannel').checked = config.HideRecordingsChannel || false;
             page.querySelector('#chkEnableSubsMaudios').checked = config.EnableSubsMaudios || false;
             page.querySelector('#chkForceDeinterlace').checked = config.ForceDeinterlace || false;
+            page.querySelector('#txtFallbackBitrate').value = config.FallbackBitrate || '0';
             Dashboard.hideLoadingMsg();
         });
     });
@@ -41,6 +42,7 @@ export default function (view, params) {
             config.HideRecordingsChannel = form.querySelector('#chkHideRecordingsChannel').checked;
             config.EnableSubsMaudios = form.querySelector('#chkEnableSubsMaudios').checked;
             config.ForceDeinterlace = form.querySelector('#chkForceDeinterlace').checked;
+            config.FallbackBitrate = form.querySelector('#txtFallbackBitrate').value;
             ApiClient.updatePluginConfiguration(TVHclientConfigurationPageVar.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
         });
         return false;


### PR DESCRIPTION
Part of a small series around Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### The problem

The plugin never tells Jellyfin how fat a channel is. `MediaSourceInfo.Bitrate` is left unset in the branch that does not probe, and the probing branch copies whatever the probe found, which on a live transport stream is not always a usable figure.

With no bitrate to work from, Jellyfin estimates one from resolution and frame rate. On broadcast material that estimate is wildly high, and it does not stay harmless:

```
-b:v 648202611   -maxrate 648202611   -bufsize 1296405222
[hevc_nvenc @ ...] InitializeEncoder failed: invalid param (8)
Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height
```

648 Mb/s asked of an encoder, for a 1280x720 50 fps H.264 source. NVENC rejects those parameters outright, so hardware transcoding fails while software transcoding, which tolerates the figure, carries on. That asymmetry is what makes it look like a GPU problem.

### What this does

Adds a setting for the bitrate to declare when the real one is not known, used in the branch that does not probe and in the probing branch when the probe comes back without a usable figure.

It defaults to `0`, meaning declare nothing, so existing installations behave exactly as they do today. Around 8000 kb/s suits HD broadcast television.

### What this does not do

It does not work out the real bitrate. That cannot be known without reading the stream, which is what probing is for. It only lets an operator who knows their source state a plausible figure instead of leaving Jellyfin to invent an implausible one.

### Reported as

Fixes #111.

### Testing

The reasoning comes from #111's own logs plus a second setup — Jellyfin 12.0, TVHeadend 4.3, DVB-T and IPTV — where the same absence of a declared bitrate produced `-b:v 400000000` on a channel actually running at about 4.6 Mb/s. The change itself is a configuration default of 0, so the untouched path is the one every current installation already follows.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one  ← you are here
- #131 — settings applied without a server restart
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.



