### PR TITLE
Apply settings without restarting the server

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
 using TVHeadEnd.DataHelper;
 using TVHeadEnd.HTSP;
@@ -42,6 +43,7 @@ namespace TVHeadEnd
         private volatile bool _initialLoadFinished;
         private volatile bool _connected;
         private volatile bool _configured;
+        private volatile bool _watchingConfiguration;
 
         private HTSConnectionAsync? _htsConnection;
         private int _priority;
@@ -105,6 +107,14 @@ namespace TVHeadEnd
 
         private void Init()
         {
+            if (!_watchingConfiguration)
+            {
+                // Reached only once Plugin.Instance exists, which is not the case while
+                // dependency injection is building this handler.
+                Plugin.Instance.ConfigurationChanged += OnConfigurationChanged;
+                _watchingConfiguration = true;
+            }
+
             if (_configured == true)
             {
                 return;
@@ -220,6 +230,38 @@ namespace TVHeadEnd
 
             _webRoot = resolved;
             _httpBaseUrl = BuildHttpBaseUrl();
+        }
+
+        private void OnConfigurationChanged(object? sender, BasePluginConfiguration configuration)
+        {
+            var config = Plugin.Instance.Configuration;
+
+            // Only the settings that describe where and as whom to connect are worth a new
+            // connection. Everything else - profile, padding, channel type, the feature
+            // flags - is read on use, so an established connection keeps serving.
+            var reconnect = !string.Equals(_tvhServerName, config.TVH_ServerName.Trim(), StringComparison.Ordinal)
+                || _httpPort != config.HTTP_Port
+                || _htspPort != config.HTSP_Port
+                || !string.Equals(_userName, config.Username.Trim(), StringComparison.Ordinal)
+                || !string.Equals(_password, config.Password.Trim(), StringComparison.Ordinal);
+
+            _configured = false;
+
+            if (!reconnect)
+            {
+                _logger.LogInformation("[TVHclient] Configuration changed, re-reading it and keeping the connection");
+                return;
+            }
+
+            _logger.LogInformation("[TVHclient] Connection settings changed, reconnecting to TVHeadend");
+
+            lock (_lock)
+            {
+                _htsConnection?.Stop();
+                _htsConnection?.Dispose();
+                _htsConnection = null;
+                _connected = false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Part of a small series around Live TV from TVHeadend. Each pull request in the series applies to `master` on its own and can be merged in any order.

### The problem

Every setting on the plugin page needs a server restart before it takes effect, and nothing on the page says so. Change the streaming profile, the padding, the container, even the password; save; and the plugin carries on with the values it read when the process started. From the outside the setting simply appears to do nothing, which is a slow and confusing thing to debug — the configuration file on disk shows the new value, so the natural conclusion is that the setting is broken rather than merely deferred.

The cause is a single guard in `HTSConnectionHandler.Init()`:

```csharp
if (_configured == true)
{
    return;
}
```

Everything read there — server name, both ports, username, password, priority, profile, channel type, and the two feature flags — is cached for the lifetime of the process.

### What this does

Jellyfin already announces the change. `BasePlugin<T>.UpdateConfiguration` raises `ConfigurationChanged` on every save:

```csharp
public virtual void UpdateConfiguration(BasePluginConfiguration configuration)
{
    ...
    SaveConfiguration(Configuration);
    ConfigurationChanged?.Invoke(this, configuration);
}
```

The handler now subscribes to it and clears the flag, so the next `Init()` re-reads everything.

Only the settings that describe the connection itself cause a reconnect — the server, either port, the username, the password. Changing a profile or a padding re-reads the configuration and leaves the established connection alone, because nothing about it has moved.

That connection carries metadata only: channels, guide, recordings, tickets. Streaming goes over HTTP with a ticket, so a reconnect never interrupts anything that is playing or recording. It is still not free — a new connection re-syncs all channel and guide data — which is why it is limited to the cases that need it.

### One implementation note

The subscription is made from inside `Init()` rather than the constructor. `Plugin.Instance` does not exist yet while dependency injection is building `HTSConnectionHandler`, and touching it there throws a `NullReferenceException` that takes the whole server down at startup — verified the hard way.

### Testing

Tested on a single setup: Jellyfin 12.0 in Docker against TVHeadend 4.3. Changing a setting and saving is now enough; before this, the same change needed a `docker restart` to show any effect.

### The series

- #127 — credentials taken out of stream URLs
- #126 — one probe per channel change instead of two
- #125 — configurable stream analysis limit
- #129 — streaming profile made configurable, with its container
- #130 — a fallback bitrate instead of an invented one
- #131 — settings applied without a server restart  ← you are here
- #132 — subtitle tracks of live channels made optional
- #124 — data streams no longer offered to Jellyfin

---

Written with Claude (Anthropic) as co-author; the commit carries a `Co-Authored-By` trailer.



