### PR TITLE
Stop putting TVHeadend credentials in stream URLs

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -228,12 +228,10 @@ namespace TVHeadEnd
         /// <returns>The HTTP base URL.</returns>
         private string BuildHttpBaseUrl()
         {
-            if (_enableSubsMaudios)
-            {
-                // Use HTTP basic auth instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                return "http://" + _userName + ":" + _password + "@" + _tvhServerName + ":" + _httpPort + _webRoot;
-            }
-
+            // Credentials must never be part of the URL. Jellyfin logs the media source path
+            // and the full ffmpeg command line, so a password placed here is written to the
+            // server log in plain text. TVHeadend's tickets are used for authentication
+            // instead, and a fresh one is requested every time a stream is opened.
             return "http://" + _tvhServerName + ":" + _httpPort + _webRoot;
         }
 

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -424,8 +424,9 @@ namespace TVHeadEnd
 
                 livetvasset.Id = channelId;
 
-                // Use HTTP basic auth in HTTP header instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
+                // A fresh ticket is requested every time this method runs, which includes the
+                // calls Jellyfin makes when the viewer switches audio or subtitle track.
+                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url;
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
                 livetvasset.AnalyzeDurationMs = 2000;
@@ -492,10 +493,26 @@ namespace TVHeadEnd
             }
         }
 
+        private string RedactCredentials(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return url;
+            }
+
+            var builder = new UriBuilder(uri)
+            {
+                UserName = string.Empty,
+                Password = string.Empty
+            };
+
+            return builder.Uri.ToString();
+        }
+
         private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Probe stream for {Source}", source);
-            _logger.LogInformation("Probe URL: {ProbeUrl}", probeUrl);
+            _logger.LogInformation("Probe URL: {ProbeUrl}", RedactCredentials(probeUrl));
 
             MediaInfoRequest req = new MediaInfoRequest
             {


### PR DESCRIPTION
When subtitles and multiple audio tracks is enabled,
 BuildHttpBaseUrl puts HTTP basic auth credentials into the stream URL
This url is then logged by jellyfin

This re-use the ticket from GetChannelStream
ands use it instead of basic auth

To avoid leaking the credentials when logging the  video probe ,
as a safety net probeUrl is replaced by RedactCredentials(probeUrl)

code written with Claude, reviewed and tested by me on DVB-T and IPTV sources
