### PR TITLE
Let the streaming profile be chosen, and say what it produces

### DIFF
--- a/TVHeadEnd/Configuration/PluginConfiguration.cs
+++ b/TVHeadEnd/Configuration/PluginConfiguration.cs
@@ -21,6 +21,8 @@ namespace TVHeadEnd.Configuration
             Password = string.Empty;
             Priority = 5;
             Profile = string.Empty;
+            StreamingProfile = string.Empty;
+            Container = "mpegts";
             Pre_Padding = 0;
             Post_Padding = 0;
             ChannelType = "Ignore";
@@ -42,6 +44,10 @@ namespace TVHeadEnd.Configuration
         public int Priority { get; set; }
 
         public string Profile { get; set; }
+
+        public string StreamingProfile { get; set; }
+
+        public string Container { get; set; }
 
         public int Pre_Padding { get; set; }
 

--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -425,14 +425,14 @@ namespace TVHeadEnd
                 livetvasset.Id = channelId;
 
                 // Use HTTP basic auth in HTTP header instead of TVH ticketing system for authentication to allow the users to switch subs or audio tracks at any time
-                livetvasset.Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Path;
+                livetvasset.Path = WithStreamingProfile(_htsConnectionHandler.GetHttpBaseUrl() + ticket.Path);
                 livetvasset.Protocol = MediaProtocol.Http;
                 livetvasset.RequiredHttpHeaders = _htsConnectionHandler.GetHeaders();
                 livetvasset.AnalyzeDurationMs = 2000;
                 livetvasset.SupportsDirectStream = false;
                 livetvasset.RequiresClosing = true;
                 livetvasset.SupportsProbing = false;
-                livetvasset.Container = "mpegts";
+                livetvasset.Container = ConfiguredContainer();
                 livetvasset.RequiresOpening = true;
                 livetvasset.IsInfiniteStream = true;
 
@@ -464,12 +464,12 @@ namespace TVHeadEnd
                 return new MediaSourceInfo
                 {
                     Id = channelId,
-                    Path = _htsConnectionHandler.GetHttpBaseUrl() + ticket.Url,
+                    Path = WithStreamingProfile(_htsConnectionHandler.GetHttpBaseUrl() + ticket.Url),
                     Protocol = MediaProtocol.Http,
                     AnalyzeDurationMs = 2000,
                     SupportsDirectStream = false,
                     SupportsProbing = false,
-                    Container = "mpegts",
+                    Container = ConfiguredContainer(),
                     MediaStreams = new List<MediaStream>
                     {
                         new MediaStream
@@ -490,6 +490,30 @@ namespace TVHeadEnd
                     }
                 };
             }
+        }
+
+        private static string WithStreamingProfile(string url)
+        {
+            var profile = Plugin.Instance.Configuration.StreamingProfile;
+
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return url;
+            }
+
+            var separator = url.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+
+            return url + separator + "profile=" + Uri.EscapeDataString(profile.Trim());
+        }
+
+        private static string ConfiguredContainer()
+        {
+            // Which container a streaming profile produces cannot be asked of TVHeadend:
+            // api/profile/list returns names only, and the class is admin only. It therefore
+            // has to be stated next to the profile it belongs to.
+            var container = Plugin.Instance.Configuration.Container;
+
+            return string.IsNullOrWhiteSpace(container) ? "mpegts" : container.Trim();
         }
 
         private async Task ProbeStream(MediaSourceInfo mediaSourceInfo, string probeUrl, string source, CancellationToken cancellationToken)
@@ -580,7 +604,10 @@ namespace TVHeadEnd
             }
             else
             {
-                _logger.LogError("Cannot probe {Source} stream", source);
+                _logger.LogError(
+                    "Cannot probe {Source} stream. It is announced as {Container}; if the streaming profile in use produces something else, ffmpeg is given the wrong demuxer and the probe cannot succeed",
+                    source,
+                    mediaSourceInfo.Container);
             }
         }
 

--- a/TVHeadEnd/Web/tvheadend.html
+++ b/TVHeadEnd/Web/tvheadend.html
@@ -26,6 +26,14 @@
                     <input is="emby-input" type="text" id="txtProfile" label="Profile for Recordings" />
                 </div>
                 <div class="inputContainer">
+                    <input is="emby-input" type="text" id="txtStreamingProfile" label="Streaming Profile" />
+                    <div class="fieldDescription">Name of the TVHeadend streaming profile to request when watching. Leave empty to use whichever profile TVHeadend has marked as default, which is what this plugin has always done.</div>
+                </div>
+                <div class="inputContainer">
+                    <input is="emby-input" type="text" id="txtContainer" label="Container that profile produces" />
+                    <div class="fieldDescription">Jellyfin is told the stream is in this container and hands it to ffmpeg, so it has to match the profile above. Leave it at mpegts for a pass-through profile; set matroska or mp4 if the profile rebuilds the stream.</div>
+                </div>
+                <div class="inputContainer">
                     <input is="emby-input" type="text" id="txtPrePadding" label="Pre-recording Padding in seconds" />
                     <div class="fieldDescription">TVHeadend stores padding in whole minutes, so values are rounded down and anything below 60 seconds has no effect.</div>
                 </div>

--- a/TVHeadEnd/Web/tvheadend.js
+++ b/TVHeadEnd/Web/tvheadend.js
@@ -14,6 +14,8 @@ export default function (view, params) {
             page.querySelector('#txtPassword').value = config.Password || '';
             page.querySelector('#txtPriority').value = config.Priority || '5';
             page.querySelector('#txtProfile').value = config.Profile || '';
+            page.querySelector('#txtStreamingProfile').value = config.StreamingProfile || '';
+            page.querySelector('#txtContainer').value = config.Container || 'mpegts';
             page.querySelector('#txtPrePadding').value = config.Pre_Padding || '0';
             page.querySelector('#txtPostPadding').value = config.Post_Padding || '0';
             page.querySelector('#selChannelType').value = config.ChannelType || 'Ignore';
@@ -35,6 +37,8 @@ export default function (view, params) {
             config.Password = form.querySelector('#txtPassword').value;
             config.Priority = form.querySelector('#txtPriority').value;
             config.Profile = form.querySelector('#txtProfile').value;
+            config.StreamingProfile = form.querySelector('#txtStreamingProfile').value;
+            config.Container = form.querySelector('#txtContainer').value;
             config.Pre_Padding = form.querySelector('#txtPrePadding').value;
             config.Post_Padding = form.querySelector('#txtPostPadding').value;
             config.ChannelType = form.querySelector('#selChannelType').value;


### PR DESCRIPTION
The container was hardcoded with :  livetvasset.Container = "mpegts";
This cause issues , as tvhh default video profile  does not necessary matches.
On tvheadend side, accessing the channel video metadata requires an admin access.
So there's no good automated way to find the video format.

Instead of trying to probe the stream which has its own issues, 
or annoucing a bad container, 
simply allow to sspecify both the profile and the container manually, 
defaulting to previously hardcoded value.

Why not force everyone to use mpegts ?
Because in setup where you can  play the video on the web client , the desktop client, the tv ;
and where you can have the iptv or dvb-t as source , mpegts is not allways the proper container.
( in France, webtv providers dont provide all channels via iptv, you need a physicaly dvb-t tunenr for the other ones)

code written with Claude, reviewed and tested by me on DVB-T and IPTV sources
